### PR TITLE
Non resonant: latest stuff

### DIFF
--- a/common/readMVA.h
+++ b/common/readMVA.h
@@ -1,0 +1,30 @@
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+#include <TMVA/Reader.h>
+
+// Does not support spectator variables yet
+float evaluateMVA(const std::string & xmlPath, const std::vector<std::pair<std::string, float>> & variables) {
+    static std::map<std::string, std::shared_ptr<TMVA::Reader>> readers;
+    static std::map<std::string, std::vector<float>> local_variables;
+    
+    auto readers_it = readers.find(xmlPath);
+    if (readers_it == readers.end()) {
+        std::shared_ptr<TMVA::Reader> reader(new TMVA::Reader("Silent=1"));
+        auto & local_mva_variables = local_variables[xmlPath];
+        local_mva_variables.resize(variables.size());
+        for (size_t i = 0; i < variables.size(); i++) {
+            reader->AddVariable(variables[i].first.c_str(), & local_mva_variables[i]);
+        }
+        reader->BookMVA("MVA", xmlPath.c_str());
+        readers.emplace(xmlPath, reader);
+        readers_it = readers.find(xmlPath);
+    }
+
+    for (size_t i = 0; i < variables.size(); i++) {
+        local_variables[xmlPath][i] = variables[i].second;
+    }
+
+    return readers_it->second->EvaluateMVA("MVA");
+}

--- a/common/reweight_v1tov3.h
+++ b/common/reweight_v1tov3.h
@@ -1,0 +1,86 @@
+#include <string>
+#include <map>
+#include <iostream>
+#include <memory>
+
+#include <TFile.h>
+#include <Math/Vector4D.h>
+#include <Math/VectorUtil.h>
+
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
+
+class BenchmarkReweighter {
+    public:
+
+        double getWeight(const uint32_t bm, const LorentzVector& h1, const LorentzVector& h2) {
+            TH2* this_th = m_weights.at(bm);
+
+            double m_hh = (h1 + h2).M();
+            double cos_theta_star = getCosThetaStar_CS(h1, h2);
+
+            int64_t binNumber = this_th->FindBin(m_hh, cos_theta_star);
+
+            return this_th->GetBinContent(binNumber);
+        }
+
+        double getWeight(const uint32_t bm, const double m_hh, const double cos_theta_star) {
+            TH2* this_th = m_weights.at(bm);
+
+            int64_t binNumber = this_th->FindBin(m_hh, cos_theta_star);
+
+            return this_th->GetBinContent(binNumber);
+        }
+
+        double getCosThetaStar_CS(const LorentzVector& h1, const LorentzVector& h2) {
+            double ebeam = 6500;
+
+            LorentzVector p1, p2;
+            p1.SetPxPyPzE(0, 0,  ebeam, ebeam);
+            p2.SetPxPyPzE(0, 0, -ebeam, ebeam);
+
+            LorentzVector hh = h1 + h2;
+            ROOT::Math::Boost boost(-hh.X() / hh.T(), -hh.Y() / hh.T(), -hh.Z() / hh.T());
+            p1 = boost(p1);
+            p2 = boost(p2);
+            LorentzVector newh1 = boost(h1);
+            ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>> CSaxis(p1.Vect().Unit() - p2.Vect().Unit());
+
+            return cos(ROOT::Math::VectorUtil::Angle(CSaxis.Unit(), newh1.Vect().Unit()));
+        }
+
+        BenchmarkReweighter() = delete;
+
+        BenchmarkReweighter(std::string baseDirPath, uint32_t nStart, uint32_t nStop) {
+            for (uint32_t bm = nStart; bm <= nStop; bm++) {
+                std::string fileName = baseDirPath + "cluster_" + std::to_string(bm) + "_v1_to_v3_weights.root";
+                TFile *file = TFile::Open(fileName.c_str());
+                if (!file || !file->IsOpen() ){
+                    std::cerr << "Error: could not open file " << fileName << std::endl;
+                    exit(1);
+                }
+                
+                TH2 *th2 = static_cast<TH2*>(file->Get("weights"));
+                if (!th2 || !th2->InheritsFrom("TH2") ) {
+                    std::cerr << "Error: could not find TH2 \"weights\" in file " << fileName << std::endl;
+                    exit(1);
+                }
+                th2->SetDirectory(0);
+                m_weights[bm] = th2;
+
+                std::cout << "Added weights histogram for benchmark nr. " << bm << std::endl;
+            }
+        }
+        
+        ~BenchmarkReweighter() {
+            for(auto& entry: m_weights)
+                delete entry.second;
+        }
+
+    private:
+        std::map<uint32_t, TH2*> m_weights;
+};
+
+static BenchmarkReweighter& getBenchmarkReweighter(std::string baseDirPath = "", uint32_t nStart = 0, uint32_t nStop = 0) {
+    static shared_ptr<BenchmarkReweighter> m_reweighter = std::make_shared<BenchmarkReweighter>(baseDirPath, nStart, nStop);
+    return *m_reweighter; 
+}

--- a/common/reweight_v1tov3.h
+++ b/common/reweight_v1tov3.h
@@ -59,7 +59,7 @@ class BenchmarkReweighter {
                     exit(1);
                 }
                 
-                TH2 *th2 = static_cast<TH2*>(file->Get("weights"));
+                TH2 *th2 = static_cast<TH2*>(file->Get("weights_unfolded"));
                 if (!th2 || !th2->InheritsFrom("TH2") ) {
                     std::cerr << "Error: could not find TH2 \"weights\" in file " << fileName << std::endl;
                     exit(1);

--- a/histFactory_hh/basePlotter.py
+++ b/histFactory_hh/basePlotter.py
@@ -4,53 +4,13 @@ import copy, sys
 
 
 class BasePlotter:
-    def __init__(self, mode = "custom", baseObjectName = "hh_llmetjj_allTight_btagM_csv", btagWP_str = 'medium', objects = "nominal", WP = ["T", "T", "T", "T", "L", "L", "M", "M", "csv"]):
-        # mode can be "custom" or "map", if you are in map mode you need to modify baseObjectName and specify a WP
+    def __init__(self, baseObjectName = "hh_llmetjj_allTight_btagM_csv", btagWP_str = 'medium', objects = "nominal", WP = ["T", "T", "T", "T", "L", "L", "M", "M", "csv"]):
         # systematic should be jecup, jecdown, jerup or jerdown. The one for lepton, btag, etc, have to be treated with the "weight" parameter in generatePlots.py (so far)
 
-        if mode == "map" :
-            print "Deprecated mode"
-            sys.exit()
-            #lepid1 = getattr(HH.lepID, WP[0])
-            #lepiso1 = getattr(HH.lepIso, WP[1])
-            #lepid2 = getattr(HH.lepID, WP[2])
-            #lepiso2 = getattr(HH.lepIso, WP[3])
-            #jetid1 = getattr(HH.jetID, WP[4])
-            #jetid2 = getattr(HH.jetID, WP[5])
-            #btagWP1 = getattr(HH.btagWP, WP[6])
-            #btagWP2 = getattr(HH.btagWP, WP[7])
-            #pair = getattr(HH.jetPair, WP[8])
-
-            #map = "hh_map_llmetjj"
-            #mapWP = HH.leplepIDIsojetjetIDbtagWPPair(lepid1, lepiso1, lepid2, lepiso2, jetid1, jetid2, btagWP1, btagWP2, pair)
-            #mapIndices = "%s[%s]"%(map, mapWP)
-            #self.baseObject = "%s[%s[0]]"%(baseObjectName, mapIndices)
-            #self.sanityCheck = "Length$(%s)>0"%mapIndices # ensure to have an entry in the map
-
-            #llIsoCat = HH.lepIso.map.at(lepiso1)+HH.lepIso.map.at(lepiso2) # This is to extract string from WP
-            #llIDCat = HH.lepID.map.at(lepid1)+HH.lepID.map.at(lepid2)
-            #jjIDCat = HH.jetID.map.at(jetid1)+HH.jetID.map.at(jetid2)
-            #jjBtagCat = HH.btagWP.map.at(btagWP1)+HH.btagWP.map.at(btagWP2)
-            #order = HH.jetPair.map.at(pair)
-            #self.suffix = 'lepIso_%s_lepID_%s_jetID_%s_btag_%s_order_%s'%(llIsoCat, llIDCat, jjIDCat, jjBtagCat, order)
-
-            ## Deprecated (but may be useful at some point)
-            #lepMap = "hh_map_l"
-            #jetMap = "hh_map_j"
-            #lepMapWP = HH.lepIDIso(lepid1, lepiso1)
-            #jetMapWP = btagWP1 # To Be Updated once jet map includes jetID
-            #lepMapIndices = "%s[%s]"%(lepMap, lepMapWP)
-            #jetMapIndices = "%s[%s]"%(jetMap, jetMapWP)
-
-        elif mode == "custom" :
-            self.baseObject = baseObjectName+"[0]"
-            self.suffix = baseObjectName
-            self.btagWP_str = btagWP_str
-
-        else : 
-            print "Mode has to be 'custom' or 'map'"
-            sys.exit()
-
+        self.baseObject = baseObjectName+"[0]"
+        self.suffix = baseObjectName
+        self.btagWP_str = btagWP_str
+        
         self.lep1_str = "hh_leptons[%s.ilep1]"%self.baseObject
         self.lep2_str = "hh_leptons[%s.ilep2]"%self.baseObject
         self.jet1_str = "hh_jets[%s.ijet1]"%self.baseObject
@@ -75,118 +35,34 @@ class BasePlotter:
         self.jet2_fwkIdx = self.jet2_str+".idx"
 
         # Ensure we have one candidate, works also for jecup etc
-        if mode == "custom" :
-            self.sanityCheck = "Length$(%s)>0"%baseObjectName
+        self.sanityCheck = "Length$(%s)>0"%baseObjectName
 
     def generatePlots(self, categories = ["All"], stage = "cleaning_cut", requested_plots = [], weights = ['trigeff', 'jjbtag', 'llidiso', 'pu'], extraCut = "", systematic = "nominal", extraString = ""):
 
         # MVA evaluation : ugly but necessary part
-        baseStringForMVA_part1 = 'evaluateMVA("/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/mvaTraining_hh/weights/BDTNAME_kBDT.weights.xml", '
-        baseStringForMVA_part2 = '{{"jj_pt", %s}, {"ll_pt", %s}, {"ll_M", %s}, {"ll_DR_l_l", %s}, {"jj_DR_j_j", %s}, {"llmetjj_DPhi_ll_jj", %s}, {"llmetjj_minDR_l_j", %s}, {"llmetjj_MTformula", %s}})'%(self.jj_str+".Pt()", self.ll_str+".Pt()", self.ll_str+".M()", self.baseObject+".DR_l_l", self.baseObject+".DR_j_j", self.baseObject+".minDR_l_j", self.baseObject+".DPhi_ll_jj", self.baseObject+".MT_formula")
+        baseStringForMVA_part1 = 'evaluateMVA("/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/mvaTraining_hh/weights/BDTNAME_kBDT.weights.xml", '
+        baseStringForMVA_part2 = '{{"jj_pt", %s}, {"ll_pt", %s}, {"ll_M", %s}, {"ll_DR_l_l", %s}, {"jj_DR_j_j", %s}, {"llmetjj_DPhi_ll_jj", %s}, {"llmetjj_minDR_l_j", %s}, {"llmetjj_MTformula", %s}})' % ( self.jj_str + ".Pt()", self.ll_str + ".Pt()", self.ll_str + ".M()", self.baseObject + ".DR_l_l", self.baseObject + ".DR_j_j", self.baseObject + ".minDR_l_j", self.baseObject + ".DPhi_ll_jj", self.baseObject + ".MT_formula")
         stringForMVA = baseStringForMVA_part1 + baseStringForMVA_part2
+        
         # The following will need to be modified each time the name of the BDT output changes
-        bdtNameTemplate = "DATE_BDT_XSPIN_MASS_SUFFIX"
-        date = "2016_02_19"  #"2016_02_06"
-        spins = ["0"] #, "2"]
-        masses = ["400", "650"]    #["350", "400", "500", "650"] #, "900"]
-        suffixs = ["VS_TT_DYHTonly_tW_8var"] #["VS_TT_8var_bTagMM"]   #["VS_TT_DY_WoverSum_8var_bTagMM_noEvtW", "VS_TT_DY_WoverSum_8var_bTagMM"]# "VS_TT09_DY01_8var_bTagMM"] #, "VS_TT1_DY0_8var_bTagMM"]
+        bdtNameTemplate = "DATE_BDT_NODE_SUFFIX"
+        date = "2016_05_27"
+        nodes = ["SM", "box", "5", "8", "13", "all"]
+        suffixes = ["VS_TT_DYHTonly_tW_8var"]
         BDToutputs = {}
         bdtNames = []
         BDToutputsVariable = {}
-        for spin in spins :
-            for mass in masses :
-                for suffix in suffixs :
-                    bdtName = bdtNameTemplate.replace("DATE", date).replace("SPIN", spin).replace("MASS", mass).replace("SUFFIX", suffix)
-                    bdtNames.append(bdtName)
-                    BDToutputsVariable[bdtName] = baseStringForMVA_part1.replace("BDTNAME", bdtName) + baseStringForMVA_part2
+        for node in nodes:
+            for suffix in suffixes :
+                bdtName = bdtNameTemplate.replace("DATE", date).replace("NODE", node).replace("SUFFIX", suffix)
+                bdtNames.append(bdtName)
+                BDToutputsVariable[bdtName] = baseStringForMVA_part1.replace("BDTNAME", bdtName) + baseStringForMVA_part2
 
         # Possible stages
         mll_cut = "((91 - {0}.M()) > 15)".format(self.ll_str) 
-        cleaning_cut = "({0}.DR_l_l < 2.2 && {1}.DR_j_j < 3.1 && {2}.DPhi_ll_jj > 1.5)".format(self.baseObject, self.baseObject, self.baseObject)
-        nminusonedrll_cut = "({0}.DR_j_j < 3.1 && {1}.DPhi_ll_jj > 1.5)".format(self.baseObject, self.baseObject)
-        nminusonedrjj_cut = "({0}.DR_l_l < 2.2 && {1}.DPhi_ll_jj > 1.5)".format(self.baseObject, self.baseObject)
-        nminusonedphilljj_cut = "({0}.DR_l_l < 2.2 && {1}.DR_j_j < 3.1)".format(self.baseObject, self.baseObject)
-        mjj_cut_sr = "({0}.M() > 95 && {0}.M() < 135)".format(self.jj_str)
-        mjj_cut_br = "({0}.M() < 95 || {0}.M() > 135)".format(self.jj_str)
-        mjj_cut_cr = "({0}.M() < 70 || {0}.M() > 150)".format(self.jj_str)
-        bdt_cut_x0_400_sr = "(({0}) > 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "400").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_400_br = "(({0}) < 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "400").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_650_sr = "(({0}) > 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "650").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_650_br = "(({0}) < 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "650").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_400_sr_ext = "(({0}) > 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "400").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_650_sr_ext = "(({0}) > 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "650").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_400_cr_ext = "(({0}) < 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "400").replace("SUFFIX", suffixs[0])])
-        bdt_cut_x0_650_cr_ext = "(({0}) < 0.1)".format(BDToutputsVariable[bdtNameTemplate.replace("DATE", date).replace("SPIN", "0").replace("MASS", "650").replace("SUFFIX", suffixs[0])])
-        safe_cut = "(%s.p4.Pt() > 30 && %s.p4.Pt() > 30 && %s.p4.Pt() > 20 && %s.p4.Pt() > 20)"%(self.jet1_str, self.jet2_str, self.lep1_str, self.lep2_str)
-        jet_pt30 = "(%s.p4.Pt() > 30 && %s.p4.Pt() > 30)"%(self.jet1_str, self.jet2_str)
-        subleadjet_pt20_30 = "(%s.p4.Pt() < 30)"%(self.jet2_str)
-        subleadjet_pt20_30_leadjet_pt30 = "(%s.p4.Pt() > 30 && %s.p4.Pt() < 30)"%(self.jet1_str, self.jet2_str)
-        mjj_cut_study = "({0}.M() > 75 && {0}.M() < 85)".format(self.jj_str)
         dict_stage_cut = {
                "no_cut" : "", 
-               "safe_cut" : safe_cut,
-               "jet_pt30" : jet_pt30,
                "mll_cut" : mll_cut,
-               "mjj_cut_study" : self.joinCuts(mjj_cut_study, mll_cut, cleaning_cut),
-               "subleadjet_pt20_30_mjj_cut_study" : self.joinCuts(mjj_cut_study, subleadjet_pt20_30, cleaning_cut, mll_cut),
-               "subleadjet_pt20_30" : self.joinCuts(subleadjet_pt20_30, cleaning_cut, mll_cut),
-               "subleadjet_pt20_30_leadjet_pt30" : self.joinCuts(subleadjet_pt20_30_leadjet_pt30, cleaning_cut, mll_cut),
-               "nminusonedrll_cut" : self.joinCuts(mll_cut, nminusonedrll_cut),
-               "nminusonedrjj_cut" : self.joinCuts(mll_cut, nminusonedrjj_cut),
-               "nminusonedphilljj_cut" : self.joinCuts(mll_cut, nminusonedphilljj_cut),
-               "cleaning_cut" : self.joinCuts(mll_cut, cleaning_cut),
-               "cleaning_cut_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, jet_pt30),
-               ###############
-               # Four regions#
-               ###############
-               "highBDT_mjjP_400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_sr),
-               "highBDT_mjjSB_400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_sr),
-               "lowBDT_mjjP_400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_br),
-               "lowBDT_mjjSB_400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br),
-               "highBDT_mjjP_650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_sr),
-               "highBDT_mjjSB_650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_sr),
-               "lowBDT_mjjP_650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_br),
-               "lowBDT_mjjSB_650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br),
-               # BDT 400 asking high BDT 650
-               "highBDT_mjjP_400_highBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_sr, bdt_cut_x0_650_sr),
-               "highBDT_mjjSB_400_highBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_sr, bdt_cut_x0_650_sr),
-               "lowBDT_mjjP_400_highBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_br, bdt_cut_x0_650_sr),
-               "lowBDT_mjjSB_400_highBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br, bdt_cut_x0_650_sr),
-               # BDT 400 asking low BDT 650
-               "highBDT_mjjP_400_lowBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_sr, bdt_cut_x0_650_br),
-               "highBDT_mjjSB_400_lowBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_sr, bdt_cut_x0_650_br),
-               "lowBDT_mjjP_400_lowBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_br, bdt_cut_x0_650_br),
-               "lowBDT_mjjSB_400_lowBDT650" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br, bdt_cut_x0_650_br),
-               # BDT 650 asking high BDT 400
-               "highBDT_mjjP_650_highBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_sr, bdt_cut_x0_400_sr),
-               "highBDT_mjjSB_650_highBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_sr, bdt_cut_x0_400_sr),
-               "lowBDT_mjjP_650_highBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_br, bdt_cut_x0_400_sr),
-               "lowBDT_mjjSB_650_highBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br, bdt_cut_x0_400_sr),
-               # BDT 650 asking low BDT 400
-               "highBDT_mjjP_650_lowBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_sr, bdt_cut_x0_400_br),
-               "highBDT_mjjSB_650_lowBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_sr, bdt_cut_x0_400_br),
-               "lowBDT_mjjP_650_lowBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_br, bdt_cut_x0_400_br),
-               "lowBDT_mjjSB_650_lowBDT400" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br, bdt_cut_x0_400_br),
-
-               "highBDT_mjjP_400_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_sr, jet_pt30),
-               "highBDT_mjjSB_400_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_sr, jet_pt30),
-               "lowBDT_mjjP_400_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_br, jet_pt30),
-               "lowBDT_mjjSB_400_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br, jet_pt30),
-               "highBDT_mjjP_650_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_sr, jet_pt30),
-               "highBDT_mjjSB_650_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_sr, jet_pt30),
-               "lowBDT_mjjP_650_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_br, jet_pt30),
-               "lowBDT_mjjSB_650_jet_pt30" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br, jet_pt30),
-
-               "allBDT_mjjSB_400" : "(" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_sr) + ") || (" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br) + ")",
-               "allBDT_mjjSB_650" : "(" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_sr) + ") || (" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br) + ")",
-               "lowBDT_mjjall_400" : "(" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_400_br) + ") || (" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_400_br) + ")",
-               "lowBDT_mjjall_650" : "(" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_sr, bdt_cut_x0_650_br) + ") || (" + self.joinCuts(mll_cut, cleaning_cut, mjj_cut_br, bdt_cut_x0_650_br) + ")",
-
-               "mjj_cr" : self.joinCuts(mll_cut, cleaning_cut, mjj_cut_cr),
-               "sr_400_ext" : self.joinCuts(mll_cut, cleaning_cut, bdt_cut_x0_400_sr_ext),
-               "sr_650_ext" : self.joinCuts(mll_cut, cleaning_cut, bdt_cut_x0_650_sr_ext),
-               "cr_400_ext" : self.joinCuts(mll_cut, cleaning_cut, bdt_cut_x0_400_cr_ext),
-               "cr_650_ext" : self.joinCuts(mll_cut, cleaning_cut, bdt_cut_x0_650_cr_ext),
                }
         # Categories
         self.dict_cat_cut =  {
@@ -352,31 +228,10 @@ class BasePlotter:
             # BDT output plots
             for bdtName in bdtNames :
                 self.bdtoutput_plot.append({
-                        'name' : 'MVA_%s_%s_%s_%s%s'%(bdtName, self.llFlav, self.suffix, self.extraString, self.systematicString),
+                        'name' : 'MVA_%s_%s_%s_%s%s' % (bdtName, self.llFlav, self.suffix, self.extraString, self.systematicString),
                         'variable' : BDToutputsVariable[bdtName],
                         'plot_cut' : self.totalCut,
-                        'binning' : '(60, -0.6, 0.7)'
-                })
-                if '400' in bdtName : 
-                    self.bdt400_plot.append({
-                                'name' : 'MVA_%s_%s_%s_%s%s'%(bdtName, self.llFlav, self.suffix, self.extraString, self.systematicString),
-                                'variable' : BDToutputsVariable[bdtName],
-                                'plot_cut' : self.totalCut,
-                                'binning' : '(60, -0.6, 0.7)'
-                        })
-                if '650' in bdtName : 
-                    self.bdt650_plot.append({
-                                'name' : 'MVA_%s_%s_%s_%s%s'%(bdtName, self.llFlav, self.suffix, self.extraString, self.systematicString),
-                                'variable' : BDToutputsVariable[bdtName],
-                                'plot_cut' : self.totalCut,
-                                'binning' : '(60, -0.6, 0.7)'
-                        })
-
-                self.mjjvsbdt_plot.append({
-                        'name' : 'MjjvsMVA_%s_%s_%s_%s%s'%(bdtName, self.llFlav, self.suffix, self.extraString, self.systematicString),
-                        'variable' : BDToutputsVariable[bdtName]+":::"+self.jj_str+".M()",
-                        'plot_cut' : self.totalCut,
-                        'binning' : '(60, -0.6, 0.7, 50, 0, 250)'
+                        'binning' : '(50, -0.6, 0.6)'
                 })
 
             # Weight Plots

--- a/histFactory_hh/generatePlots.py
+++ b/histFactory_hh/generatePlots.py
@@ -23,8 +23,7 @@ getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_8_0_6/src/cp
 
 sample_weights = {}
 for node in range(1, 13):
-    node_str = str(node)
-    sample_weights[ "cluster_" + node_str ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
+    sample_weights[ "cluster_node_" + str(node) ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
 
 # Plot configuration
 
@@ -56,13 +55,12 @@ for systematicType in systematics.keys() :
         ## lljj 
         basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = objects)
         plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
-        ##plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
  
         ## llbb 
         basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = objects)
         plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
-        plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
+        #plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
 
 
 objects = "nominal"

--- a/histFactory_hh/generatePlots.py
+++ b/histFactory_hh/generatePlots.py
@@ -6,9 +6,28 @@ scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe
 sys.path.append(scriptDir)
 from basePlotter import *
 from HHAnalysis import HH
-includes = ["/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/histFactory_hh/readMVA.h"]
 
+includes = []
 plots = []
+code_before_loop = ""
+
+# Needed to evaluate MVA outputs
+includes.append( os.path.join(scriptDir, "..", "common", "readMVA.h") )
+
+# For cluster reweighting
+includes.append( os.path.join(scriptDir, "..", "common", "reweight_v1tov3.h") )
+
+code_before_loop += """
+getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_8_0_6/src/cp3_llbb/HHTools/scripts/", 0, 11);
+"""
+
+sample_weights = {}
+for node in range(1, 13):
+    node_str = str(node)
+    sample_weights[ "cluster_" + node_str ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
+
+# Plot configuration
+
 # lljj 
 weights_lljj = ['trigeff', 'llidiso', 'pu']
 categories_lljj = ["All"] 
@@ -19,76 +38,37 @@ plots_lljj = ["mll", "mjj", "basic", "csv", "bdtinput"]
 weights_llbb = ['trigeff', 'llidiso', 'pu', 'jjbtag']
 categories_llbb = ["All"]
 stage_llbb = "no_cut"
-plots_llbb = plots_lljj 
-
-#categories_llbb_clean = ["All"]
-#categories_llbb_combine = ["All", "ElEl", "MuMu", "MuEl"]
-#baseObjectName_llbb = "hh_llmetjj_HWWleptons_btagM_csv"
-#stage_llbb_clean = "cleaning_cut"
+plots_llbb = plots_lljj
+#plots_llbb = ["bdtinput", "mjj"]
 
 systematics = {"modifObjects" : ["nominal"]}
 #systematics = {"modifObjects" : ["nominal", "jecup", "jecdown", "jerup", "jerdown"], "SF" : ["elidisoup", "elidisodown", "muidup", "muiddown", "muisoup", "muisodown", "jjbtagup", "jjbtagdown", "puup", "pudown", "trigeffup", "trigeffdown", "pdfup", "pdfdown", "scale"]}
 extraSys = []
+
 for systematicType in systematics.keys() :
+    
     for systematic in systematics[systematicType]:
         if systematicType == "modifObjects" :
             objects = systematic
         else : 
             objects = "nominal" #ensure that we use normal hh_objects for systematics not modifying obect such as scale factors 
 
-        # lljj 
-        basePlotter = BasePlotter(mode = "custom", baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = objects)
+        ## lljj 
+        basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = objects)
         plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
-        #plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
-        
-        # llbb 
-        basePlotter = BasePlotter(mode = "custom", baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = objects)
+        ##plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
+ 
+        ## llbb 
+        basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = objects)
         plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
-        #plots.extend(basePlotter.generatePlots(["ElEl", "MuEl", "MuMu"], "no_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["mll"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "nminusonedrll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["drllcut"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "nminusonedrjj_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["drjjcut"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "nminusonedphilljj_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["dphilljjcut"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["cleancut"]))
-       
-        # llbb after pre-selection
-        #basePlotter = BasePlotter(mode = "custom", baseObjectName = baseObjectName_llbb, btagWP_str = 'medium', objects = objects)
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, stage_llbb_clean, systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "mjj", "basic"]))# "llidisoWeight", 'jjbtagWeight', 'trigeffWeight', 'puWeight']))
-
-#       # # Control plots  
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "mjj_cr", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtinput", "bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "cr_400_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "cr_650_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["mjj", "bdtinput"]))
-
-        ## Plots in the four regions
-        #basePlotter = BasePlotter(mode = "custom", baseObjectName = baseObjectName_llbb, btagWP_str = 'medium', objects = objects)
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjP_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjP_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjSB_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjSB_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjP_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjP_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjSB_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjSB_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl", "bdtoutput", "mjj", "bdtinput"]))
-        ## BDT low and high
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "sr_400_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtinput", "mjj"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "sr_650_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtinput", "mjj"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "cr_400_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtinput", "mjj"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb, "cr_650_ext", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtinput", "mjj"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "lowBDT_mjjall_400", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "lowBDT_mjjall_650", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "highBDT_mjjall_400", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "highBDT_mjjall_650", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "allBDT_mjjSB_400", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "allBDT_mjjSB_650", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "allBDT_mjjP_400", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
-        #plots.extend(basePlotter.generatePlots(categories_llbb_clean, "allBDT_mjjP_650", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
+        plots.extend(basePlotter.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
 
 
 objects = "nominal"
 systematic = "nominal"
 ## Plots for ht and n vertex
-#basePlotter = BasePlotter(mode = "custom", baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = 'nominal')
+#basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = 'nominal')
 #plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = "nominal", weights = ['trigeff', 'llidiso', 'pu'], requested_plots = ["vertex"]))
 #plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = "nominal", weights = ['trigeff', 'llidiso'], requested_plots = ["vertex"], extraString = "_noPuWeight"))
 #plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = "nominal", weights = [], requested_plots = ["ht"]))
@@ -96,7 +76,7 @@ systematic = "nominal"
 #plots.extend(basePlotter.generatePlots(categories_lljj, stage_lljj, systematic = "nominal", weights = ['trigeff', 'llidiso', 'pu'], requested_plots = ["flavour"]))
 for systematic in extraSys : #does not need modify objects
     # Plots in the four regions for limits
-    basePlotter = BasePlotter(mode = "custom", baseObjectName = baseObjectName_llbb, btagWP_str = 'medium', objects = objects)
+    basePlotter = BasePlotter(baseObjectName = baseObjectName_llbb, btagWP_str = 'medium', objects = objects)
     plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjP_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
     plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjP_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
     plots.extend(basePlotter.generatePlots(categories_llbb, "lowBDT_mjjSB_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
@@ -105,9 +85,3 @@ for systematic in extraSys : #does not need modify objects
     plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjP_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
     plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjSB_400", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
     plots.extend(basePlotter.generatePlots(categories_llbb, "highBDT_mjjSB_650", systematic = systematic, weights = weights_llbb, requested_plots = ["isElEl"]))
-
-#for plot in plots : 
-#    print plot
-#    #print plot["name"]
-#    print " "
-

--- a/histFactory_hh/launchHistFactory.py
+++ b/histFactory_hh/launchHistFactory.py
@@ -29,25 +29,23 @@ IDs = []
 IDsToSplitMore = []
 IDsToSplitLitleMore = []
 
-#POSTMORIOND
-#IDs.extend([1507, 1508, 1509, 1510, 1511, 1512, 1513, 1514, 1515, 1516, 1517, 1518, 1519, 1520, 1521, 1522, 1523, 1524, 1525, 1526, 1527, 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1537, 1538, 1539, 1540, 1541, 1542, 1543, 1544, 1545, 1546, 1547, 1548, 1549, 1550, 1551, 1552, 1553, 1554, 1555, 1556, 1557, 1558, 1559, 1560, 1561, 1562, 1563, 1564, 1566, 1567, 1568, 1569, 1570, 1571, 1572, 1573, 1574, 1575, 1576, 1577, 1578, 1579, 1580, 1581, 1582, 1583, 1584, 1585, 1586, 1587, 1588, 1589, 1590, 1591, 1592, 1593, 1594, 1595, 1596, 1597, 1598, 1599, 1600, 1601, 1602, 1603, 1604, 1605, 1606, 1607, 1608, 1609, 1610])
-#IDsToSplitMore.extend([1507, 1511, 1512, 1514, 1516, 1520, 1522, 1523, 1524, 1525, 1526, 1528, 1529, 1531, 1532, 1533, 1534, 1537, 1542, 1546, 1556, 1558, 1564, 1568, 1569, 1570, 1571, 1572, 1573, 1574, 1575, 1576, 1577, 1578, 1580, 1581, 1587, 1588, 1598, 1601, 1604])
-
-# ICHEPv0
-
-# All backgrounds and signals:
-#IDs.extend([1614, 1615, 1616, 1617, 1618, 1619, 1620, 1621, 1622, 1623, 1624, 1625, 1626, 1627, 1628, 1629, 1630, 1631, 1632, 1633, 1634, 1635, 1636, 1637, 1638, 1639, 1640, 1641, 1642, 1643, 1644, 1645, 1646, 1647, 1648, 1649, 1650, 1651, 1652, 1653, 1654, 1655, 1656, 1657, 1658, 1659, 1660, 1661, 1662, 1663, 1664, 1665, 1666, 1667, 1668, 1669, 1670, 1671, 1672, 1673, 1674, 1675, 1676, 1677, 1678, 1679, 1680, 1681, 1682, 1683, 1684, 1685, 1686, 1687, 1688, 1689, 1690, 1691, 1692, 1693, 1694, 1695, 1696, 1697, 1698, 1699, 1700, 1701, 1702, 1703, 1704, 1705, 1706, 1707, 1708, 1709, 1710, 1711, 1712, 1713, 1714, 1715, 1716, 1717, 1718, 1719, 1720, 1721, 1722, 1723, 1724, 1725, 1726, 1727, 1728, 1729, 1730, 1731, 1732, 1733, 1734, 1735, 1736, 1737, 1738, 1739])
+# Data
+#IDs.extend([
+#    1642, # DoubleEG
+#    1662, # MuonEG
+#    1716, # DoubleMuon
+#    ])
 
 # Main backgrounds:
 #IDs.extend([
-#    1658, # tW 
-#    1666, # tW
-#    1715, # sT t-chan
+#    #1658, # tW 
+#    #1666, # tW
+#    #1715, # sT t-chan
 #    1718, # TT incl NLO
-#    #1733, # DY M10-50 NLO merged
-#    #1734, # DY M-50 NLO merged 
+#    1733, # DY M10-50 NLO merged
+#    1734, # DY M-50 NLO merged 
 #    ])
-#
+
 ## DY LO
 #IDs.extend([
 #    # M-50 incl. merged
@@ -57,21 +55,101 @@ IDsToSplitLitleMore = []
 #    1679,
 #    1736,
 #    1737,
-#    # M-5to50 incl.
-#    1717,
+#    # M-5to50 incl.: forget it...
+#    #1717,
 #    # M-5to50, binned HT
 #    1738,
 #    1705,
 #    1680,
 #    1735,
 #    ])
-IDs.extend([1737])
+
+# Other backgrounds
+# VV
+#IDs.extend([
+#    #1624, # VV(2L2Nu)
+#    
+#    1691, # WW(LNuQQ)
+#    1703, # WW(2L2Nu)
+#    
+#    1615, # WZ(3LNu)
+#    1701, # WZ(L3Nu)
+#    1721, # WZ(LNu2Q)
+#    1725, # WZ(2L2Q)
+#    
+#    1723, # ZZ(4L)
+#    1727, # ZZ(2L2Nu)
+#    1729, # ZZ(2L2Q)
+#    
+#    1633, # WZZ
+#    ])
+#
+## Higgs
+#IDs.extend([
+#    # ggH ==> no H(ZZ)?
+#    1650, # H(WW(2L2Nu))
+#    1656, # H(BB)
+#
+#    # ZH
+#    1616, # ggZ(LL)H(WW(2L2Nu))
+#    1653, # ZH(WW)
+#    1628, # ggZ(LL)H(BB)
+#    1644, # Z(LL)H(BB)
+#    1657, # Z(NuNu)H(BB)
+#    
+#    # VBF
+#    1629, # VBFH(BB)
+#    1690, # VBFH(WW(2L2Nu))
+#
+#    # WH
+#    1643, # W+(LNu)H(BB)
+#    1692, # W-(LNu)H(BB)
+#    1659, # W+H(WW)
+#    1664, # W-H(WW)
+#
+#    # bbH
+#    1687, # bbH(BB) ybyt
+#    1641, # bbH(BB) yb2
+#    ])
+#
+## Wjets
+#IDs.extend([
+#    1648, # JetsLNu
+#    ])
+#
+## QCD ==> 30to50 missing
+#IDs.extend([
+#    1661, # Pt-15to20EMEnriched
+#    1671, # Pt-20to30EMEnriched
+#    1681, # Pt-50to80EMEnriched
+#    1637, # Pt-80to120EMEnriched
+#    1632, # Pt-120to170EMEnriched
+#    1670, # Pt-170to300EMEnriched
+#    1645, # Pt-300toInfEMEnriched
+#    #1719, # Pt-20toInfMuEnriched
+#    ])
+#
+## Top
+#IDs.extend([
+#    1688, # sT s-channel
+#    1622, # TTW(LNu)
+#    1675, # TTW(QQ)
+#    1693, # TTZ(2L2Nu)
+#    1702, # TTZ(QQ),
+#    1694, # ttH(bb)
+#    1710, # ttH(nonbb)
+#    #1711, # TT(2L2Nu)
+#    ])
 
 # Resonant
 #IDs.extend([1617, 1625, 1630, 1631, 1638, 1640, 1647, 1652, 1654, 1660, 1665, 1668, 1669, 1674, 1676, 1678, 1685, 1686, 1689, 1695, 1699, 1700, 1704, 1706, 1708, 1728])
 
 # NonResonant
-IDs.extend([1614, 1618, 1626, 1634, 1635, 1639, 1651, 1672, 1673, 1677, 1684, 1697, 1698, 1722])
+IDs.extend([
+    #1651, # SM
+    1672, # box
+    ])
+#IDs.extend([1614, 1618, 1626, 1634, 1635, 1639, 1673, 1677, 1684, 1697, 1698, 1722])
 
 parser = argparse.ArgumentParser(description='Facility to submit histFactory jobs on condor.')
 parser.add_argument('-o', '--output', dest='output', default=str(datetime.date.today()), help='Name of the output directory.')
@@ -98,7 +176,7 @@ if args.test :
 
 samples = []
 for ID in IDs:
-    filesperJob = 10
+    filesperJob = 15
     if ID in IDsToSplitMore :
         filesperJob = 5
     if ID in IDsToSplitLitleMore :
@@ -150,27 +228,40 @@ if args.filter :
     for jsonSampleFilePath in jsonSampleFileList : 
         with open(jsonSampleFilePath, 'r') as jsonSampleFile :
             jsonSample = json.load(jsonSampleFile)
-            for sampleName in  jsonSample.keys():
-#                if 'TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2' in sampleName : 
-#
-#                    ttflname = sampleName.replace("TT_Tune", "TT_FL_Tune")
-#                    jsonSample[ttflname] = copy.deepcopy(jsonSample[sampleName])
-#                    jsonSample[ttflname]["sample_cut"] = "(hh_gen_ttbar_decay_type >= 4 && hh_gen_ttbar_decay_type <= 10 && hh_gen_ttbar_decay_type != 7)"
-#                    jsonSample[ttflname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_FL_Tune")
-#
-#                    ttslname = sampleName.replace("TT_Tune", "TT_SL_Tune")
-#                    jsonSample[ttslname] = copy.deepcopy(jsonSample[sampleName])
-#                    jsonSample[ttslname]["sample_cut"] = "(hh_gen_ttbar_decay_type == 2 || hh_gen_ttbar_decay_type == 3 || hh_gen_ttbar_decay_type == 7)"
-#                    jsonSample[ttslname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_SL_Tune")
-#
-#                    ttfhname = sampleName.replace("TT_Tune", "TT_FH_Tune")
-#                    jsonSample[ttfhname] = copy.deepcopy(jsonSample[sampleName])
-#                    jsonSample[ttfhname]["sample_cut"] = "(hh_gen_ttbar_decay_type == 1)"
-#                    jsonSample[ttfhname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_FH_Tune")
-#                    jsonSample.pop(sampleName)
+            for sampleName in jsonSample.keys():
+                if 'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2' in sampleName : 
+
+                    ttflname = sampleName.replace("TT_Tune", "TT_FL_Tune")
+                    jsonSample[ttflname] = copy.deepcopy(jsonSample[sampleName])
+                    jsonSample[ttflname]["sample_cut"] = "(hh_gen_ttbar_decay_type >= 4 && hh_gen_ttbar_decay_type <= 10 && hh_gen_ttbar_decay_type != 7)"
+                    jsonSample[ttflname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_FL_Tune")
+
+                    ttslname = sampleName.replace("TT_Tune", "TT_SL_Tune")
+                    jsonSample[ttslname] = copy.deepcopy(jsonSample[sampleName])
+                    jsonSample[ttslname]["sample_cut"] = "(hh_gen_ttbar_decay_type == 2 || hh_gen_ttbar_decay_type == 3 || hh_gen_ttbar_decay_type == 7)"
+                    jsonSample[ttslname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_SL_Tune")
+
+                    ttfhname = sampleName.replace("TT_Tune", "TT_FH_Tune")
+                    jsonSample[ttfhname] = copy.deepcopy(jsonSample[sampleName])
+                    jsonSample[ttfhname]["sample_cut"] = "(hh_gen_ttbar_decay_type == 1)"
+                    jsonSample[ttfhname]["output_name"] = jsonSample[sampleName]["output_name"].replace("TT_Tune", "TT_FH_Tune")
+                    
+                    jsonSample.pop(sampleName)
+                
                 if 'DYJetsToLL_M-5to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8' in sampleName or 'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8' in sampleName : 
                 #if 'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX_MiniAODv2' in sampleName or 'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX_MiniAODv2' in sampleName : 
                     jsonSample[sampleName]["sample_cut"] = "event_ht < 100"
+
+                # Handle the cluster v1tov3 reweighting
+                if "merged" in sampleName:
+                    for node in range(1, 13):
+                        node_str = str(node)
+                        print "Changing box to reweight to benchmark {}".format(node_str)
+                        newName = sampleName.replace("merged", node_str)
+                        jsonSample[newName] = copy.deepcopy(jsonSample[sampleName])
+                        jsonSample[newName]["sample-weight"] = "cluster_" + node_str
+                        jsonSample[newName]["output_name"] = jsonSample[sampleName]["output_name"].replace("box", node_str)
+                    jsonSample.pop(sampleName)
 
         with open(jsonSampleFilePath, 'w+') as jsonSampleFile :
             json.dump(jsonSample, jsonSampleFile)

--- a/histFactory_hh/launchHistFactory.py
+++ b/histFactory_hh/launchHistFactory.py
@@ -29,41 +29,41 @@ IDs = []
 IDsToSplitMore = []
 IDsToSplitLitleMore = []
 
-# Data
+## Data
 #IDs.extend([
 #    1642, # DoubleEG
 #    1662, # MuonEG
 #    1716, # DoubleMuon
 #    ])
+#
+## Main backgrounds:
+IDs.extend([
+    1658, # tW 
+    1666, # tW
+    1715, # sT t-chan
+    1718, # TT incl NLO
+    1733, # DY M10-50 NLO merged
+    1734, # DY M-50 NLO merged 
+    ])
 
-# Main backgrounds:
-#IDs.extend([
-#    #1658, # tW 
-#    #1666, # tW
-#    #1715, # sT t-chan
-#    1718, # TT incl NLO
-#    1733, # DY M10-50 NLO merged
-#    1734, # DY M-50 NLO merged 
-#    ])
-
-## DY LO
-#IDs.extend([
-#    # M-50 incl. merged
-#    1739,
-#    # M-50, binned HT > 100
-#    1731,
-#    1679,
-#    1736,
-#    1737,
-#    # M-5to50 incl.: forget it...
-#    #1717,
-#    # M-5to50, binned HT
-#    1738,
-#    1705,
-#    1680,
-#    1735,
-#    ])
-
+### DY LO
+IDs.extend([
+    # M-50 incl. merged
+    1739,
+    # M-50, binned HT > 100
+    1731,
+    1679,
+    1736,
+    1737,
+    # M-5to50 incl.: forget it...
+    1717,
+    # M-5to50, binned HT
+    1738,
+    1705,
+    1680,
+    1735,
+    ])
+#
 # Other backgrounds
 # VV
 #IDs.extend([
@@ -145,11 +145,21 @@ IDsToSplitLitleMore = []
 #IDs.extend([1617, 1625, 1630, 1631, 1638, 1640, 1647, 1652, 1654, 1660, 1665, 1668, 1669, 1674, 1676, 1678, 1685, 1686, 1689, 1695, 1699, 1700, 1704, 1706, 1708, 1728])
 
 # NonResonant
-IDs.extend([
-    #1651, # SM
-    1672, # box
-    ])
+#IDs.extend([
+#    #1651, # SM
+#    1672, # box
+#    ])
 #IDs.extend([1614, 1618, 1626, 1634, 1635, 1639, 1673, 1677, 1684, 1697, 1698, 1722])
+
+# NonResonant with GEN info
+IDs.extend([
+    1765, # SM
+    1760, # box
+    ])
+#IDs.extend([1768, 1767, 1748, 1763, 1753, 1757, 1764, 1756, 1759, 1751, 1755, 1762])
+
+# NonResonant merged
+IDs.append(1769)
 
 parser = argparse.ArgumentParser(description='Facility to submit histFactory jobs on condor.')
 parser.add_argument('-o', '--output', dest='output', default=str(datetime.date.today()), help='Name of the output directory.')
@@ -163,7 +173,7 @@ parser.add_argument('--tree', dest='treeFactory', action='store_true', default=F
 
 args = parser.parse_args()
 
-sample = get_sample(IDs[0])
+sample = get_sample(1769)
 files = ["/storage/data/cms/" + x.lfn for x  in sample.files]
 
 if args.test : 
@@ -176,7 +186,7 @@ if args.test :
 
 samples = []
 for ID in IDs:
-    filesperJob = 15
+    filesperJob = 7
     if ID in IDsToSplitMore :
         filesperJob = 5
     if ID in IDsToSplitLitleMore :
@@ -253,14 +263,13 @@ if args.filter :
                     jsonSample[sampleName]["sample_cut"] = "event_ht < 100"
 
                 # Handle the cluster v1tov3 reweighting
-                if "merged" in sampleName:
+                if "all_nodes" in sampleName:
                     for node in range(1, 13):
-                        node_str = str(node)
-                        print "Changing box to reweight to benchmark {}".format(node_str)
-                        newName = sampleName.replace("merged", node_str)
+                        node_str = "node_" + str(node)
+                        newName = sampleName.replace("all_nodes", node_str)
                         jsonSample[newName] = copy.deepcopy(jsonSample[sampleName])
                         jsonSample[newName]["sample-weight"] = "cluster_" + node_str
-                        jsonSample[newName]["output_name"] = jsonSample[sampleName]["output_name"].replace("box", node_str)
+                        jsonSample[newName]["output_name"] = jsonSample[sampleName]["output_name"].replace("all_nodes", node_str)
                     jsonSample.pop(sampleName)
 
         with open(jsonSampleFilePath, 'w+') as jsonSampleFile :

--- a/mvaTraining_hh/trainMVA.py
+++ b/mvaTraining_hh/trainMVA.py
@@ -17,14 +17,20 @@ def get_sample(name):
     return resultset.one()
 
 
-date = "2016_05_27"
+#date = "2016_05_27"
+date = "2016_06_10"
 suffix = "VS_TT_DYHTonly_tW_8var"
 label_template = "DATE_BDT_NODE_SUFFIX"
 
-#nodes = ["SM"]
-#nodes = ["SM", "box", "5", "8", "13"]
-nodes = ["SM", "box", "2", "3", "4", "5", "7", "8", "9", "10", "11", "12", "13"]
-inFileDir = "/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/skim_160527_0/condor/output/"
+# v1 training
+#nodes = ["SM", "box", "5", "8", "13"] # v1 nodes for separate training
+#nodes = ["2", "3", "4", "5", "7", "8", "9", "10", "11", "12", "13"] # v1 nodes for "all" training
+#inFileDir = "/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/skim_160527_0/condor/output/"
+
+# v2 training
+nodes = ["SM", "2", "5", "6", "12"] # v1 nodes for separate training
+#nodes = ["2", "3", "4", "5", "7", "8", "9", "10", "11", "12", "13"] # v1 nodes for "all" training
+inFileDir = "/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/skim_160610_0/condor/output/"
 
 # SAMPLES FOR THE TRAINING
 
@@ -61,6 +67,12 @@ DY5to50_HT400to600_db = get_sample(unicode(DY5to50_HT400to600))
 DY5to50_HT600toInf = "DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0"
 DY5to50_HT600toInf_db = get_sample(unicode(DY5to50_HT600toInf))
 
+DYJetsToLL_M10to50 = "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext3_v0.1.2+76X_HHAnalysis_2016-05-02.v0"
+DYJetsToLL_M10to50_db = get_sample(unicode(DYJetsToLL_M10to50))
+
+DYJetsToLL_M50 = "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext4_v0.1.2+76X_HHAnalysis_2016-05-02.v0"
+DYJetsToLL_M50_db = get_sample(unicode(DYJetsToLL_M50))
+
 ST_tw = "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0"
 ST_tw_db = get_sample(unicode(ST_tw))
 ST_tbarw = "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0"
@@ -71,45 +83,53 @@ bkgFiles = {
                     "files" : [inFileDir+ttSample+"_histos.root"],
                     "relativeWeight" : ttDbSample.source_dataset.xsection/ttDbSample.event_weight_sum
                 },
-        "DY50_incl" : { 
-                    "files" : [inFileDir+DY50_incl+"_histos.root"],
-                    "relativeWeight" : DY50_incl_db.source_dataset.xsection/DY50_incl_db.event_weight_sum
-                },
-        "DY50_HT100to200" : { 
-                    "files" : [inFileDir+DY50_HT100to200+"_histos.root"],
-                    "relativeWeight" : DY50_HT100to200_db.source_dataset.xsection/DY50_HT100to200_db.event_weight_sum
-                },
-        "DY50_HT200to400" : { 
-                    "files" : [inFileDir+DY50_HT200to400+"_histos.root"],
-                    "relativeWeight" : DY50_HT200to400_db.source_dataset.xsection/DY50_HT200to400_db.event_weight_sum
-                },
-        "DY50_HT400to600" : { 
-                    "files" : [inFileDir+DY50_HT400to600+"_histos.root"],
-                    "relativeWeight" : DY50_HT400to600_db.source_dataset.xsection/DY50_HT400to600_db.event_weight_sum
-                },
-        "DY50_HT600toInf" : { 
-                    "files" : [inFileDir+DY50_HT600toInf+"_histos.root"],
-                    "relativeWeight" : DY50_HT600toInf_db.source_dataset.xsection/DY50_HT600toInf_db.event_weight_sum
-                },
-        #"DY5to50_incl" : { 
-        #            "files" : [inFileDir+DY5to50_incl+"_histos.root"],
-        #            "relativeWeight" : DY5to50_incl_db.source_dataset.xsection/DY5to50_incl_db.event_weight_sum
+        #"DY50_incl" : { 
+        #            "files" : [inFileDir+DY50_incl+"_histos.root"],
+        #            "relativeWeight" : DY50_incl_db.source_dataset.xsection/DY50_incl_db.event_weight_sum
         #        },
-        "DY5to50_HT100to200" : { 
-                    "files" : [inFileDir+DY5to50_HT100to200+"_histos.root"],
-                    "relativeWeight" : DY5to50_HT100to200_db.source_dataset.xsection/DY5to50_HT100to200_db.event_weight_sum
+        #"DY50_HT100to200" : { 
+        #            "files" : [inFileDir+DY50_HT100to200+"_histos.root"],
+        #            "relativeWeight" : DY50_HT100to200_db.source_dataset.xsection/DY50_HT100to200_db.event_weight_sum
+        #        },
+        #"DY50_HT200to400" : { 
+        #            "files" : [inFileDir+DY50_HT200to400+"_histos.root"],
+        #            "relativeWeight" : DY50_HT200to400_db.source_dataset.xsection/DY50_HT200to400_db.event_weight_sum
+        #        },
+        #"DY50_HT400to600" : { 
+        #            "files" : [inFileDir+DY50_HT400to600+"_histos.root"],
+        #            "relativeWeight" : DY50_HT400to600_db.source_dataset.xsection/DY50_HT400to600_db.event_weight_sum
+        #        },
+        #"DY50_HT600toInf" : { 
+        #            "files" : [inFileDir+DY50_HT600toInf+"_histos.root"],
+        #            "relativeWeight" : DY50_HT600toInf_db.source_dataset.xsection/DY50_HT600toInf_db.event_weight_sum
+        #        },
+        ##"DY5to50_incl" : { 
+        ##            "files" : [inFileDir+DY5to50_incl+"_histos.root"],
+        ##            "relativeWeight" : DY5to50_incl_db.source_dataset.xsection/DY5to50_incl_db.event_weight_sum
+        ##        },
+        #"DY5to50_HT100to200" : { 
+        #            "files" : [inFileDir+DY5to50_HT100to200+"_histos.root"],
+        #            "relativeWeight" : DY5to50_HT100to200_db.source_dataset.xsection/DY5to50_HT100to200_db.event_weight_sum
+        #        },
+        #"DY5to50_HT200to400" : { 
+        #            "files" : [inFileDir+DY5to50_HT200to400+"_histos.root"],
+        #            "relativeWeight" : DY5to50_HT200to400_db.source_dataset.xsection/DY5to50_HT200to400_db.event_weight_sum
+        #        },
+        #"DY5to50_HT400to600" : { 
+        #            "files" : [inFileDir+DY5to50_HT400to600+"_histos.root"],
+        #            "relativeWeight" : DY5to50_HT400to600_db.source_dataset.xsection/DY5to50_HT400to600_db.event_weight_sum
+        #        },
+        #"DY5to50_HT600toInf" : { 
+        #            "files" : [inFileDir+DY5to50_HT600toInf+"_histos.root"],
+        #            "relativeWeight" : DY5to50_HT600toInf_db.source_dataset.xsection/DY5to50_HT600toInf_db.event_weight_sum
+        #        },
+        "DYJetsToLL_M-10to50": {
+                    "files": [inFileDir+DYJetsToLL_M10to50+"_histos.root"],
+                    "relativeWeight": DYJetsToLL_M10to50_db.source_dataset.xsection/DYJetsToLL_M10to50_db.event_weight_sum
                 },
-        "DY5to50_HT200to400" : { 
-                    "files" : [inFileDir+DY5to50_HT200to400+"_histos.root"],
-                    "relativeWeight" : DY5to50_HT200to400_db.source_dataset.xsection/DY5to50_HT200to400_db.event_weight_sum
-                },
-        "DY5to50_HT400to600" : { 
-                    "files" : [inFileDir+DY5to50_HT400to600+"_histos.root"],
-                    "relativeWeight" : DY5to50_HT400to600_db.source_dataset.xsection/DY5to50_HT400to600_db.event_weight_sum
-                },
-        "DY5to50_HT600toInf" : { 
-                    "files" : [inFileDir+DY5to50_HT600toInf+"_histos.root"],
-                    "relativeWeight" : DY5to50_HT600toInf_db.source_dataset.xsection/DY5to50_HT600toInf_db.event_weight_sum
+        "DYJetsToLL_M-50": {
+                    "files": [inFileDir+DYJetsToLL_M50+"_histos.root"],
+                    "relativeWeight": DYJetsToLL_M50_db.source_dataset.xsection/DYJetsToLL_M50_db.event_weight_sum
                 },
         "ST_tw" : { 
                     "files" : [inFileDir+ST_tw+"_histos.root"],
@@ -137,22 +157,40 @@ discriList = [
 spectatorList = []
 cut = "(91 - ll_M) > 15"
 MVAmethods = ["kBDT"]
-weightExpr = "event_weight * trigeff * jjbtag * llidiso * pu"
+weightExpr = "event_weight * trigeff * jjbtag * llidiso * pu * sample_weight"
 
 if __name__ == '__main__':
 
-    sigFiles = {}
     
     for node in nodes:
             
+        sigFiles = {}
+        
         sigFiles[node] = {
-                            "files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root".format(node) ],
+                            "files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root".format(node) ], # v3
+                            #"files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root".format(node) ], # v1
                             "relativeWeight" : 1.
                         }
             
-    label = label_template.replace("DATE", date).replace("NODE", "all").replace("SUFFIX", suffix)
+        label = label_template.replace("DATE", date).replace("NODE", str(node)).replace("SUFFIX", suffix)
         
-    print bkgFiles, sigFiles
+        print bkgFiles, sigFiles
         
-    trainMVA(bkgFiles, sigFiles, discriList, cut, weightExpr, MVAmethods, spectatorList, label)
+        trainMVA(bkgFiles, sigFiles, discriList, cut, weightExpr, MVAmethods, spectatorList, label)
+
+    #sigFiles = {}
+    #
+    #for node in nodes:
+    #        
+    #    sigFiles[node] = {
+    #                        "files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root".format(node) ], # v3
+    #                        #"files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root".format(node) ], # v1
+    #                        "relativeWeight" : 1.
+    #                    }
+    #        
+    #label = label_template.replace("DATE", date).replace("NODE", "all").replace("SUFFIX", suffix)
+    #    
+    #print bkgFiles, sigFiles
+    #    
+    #trainMVA(bkgFiles, sigFiles, discriList, cut, weightExpr, MVAmethods, spectatorList, label)
 

--- a/mvaTraining_hh/trainMVA.py
+++ b/mvaTraining_hh/trainMVA.py
@@ -23,7 +23,7 @@ label_template = "DATE_BDT_NODE_SUFFIX"
 
 #nodes = ["SM"]
 #nodes = ["SM", "box", "5", "8", "13"]
-nodes = ["box", "5", "8", "13"]
+nodes = ["SM", "box", "2", "3", "4", "5", "7", "8", "9", "10", "11", "12", "13"]
 inFileDir = "/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/skim_160527_0/condor/output/"
 
 # SAMPLES FOR THE TRAINING
@@ -91,10 +91,10 @@ bkgFiles = {
                     "files" : [inFileDir+DY50_HT600toInf+"_histos.root"],
                     "relativeWeight" : DY50_HT600toInf_db.source_dataset.xsection/DY50_HT600toInf_db.event_weight_sum
                 },
-        "DY5to50_incl" : { 
-                    "files" : [inFileDir+DY5to50_incl+"_histos.root"],
-                    "relativeWeight" : DY5to50_incl_db.source_dataset.xsection/DY5to50_incl_db.event_weight_sum
-                },
+        #"DY5to50_incl" : { 
+        #            "files" : [inFileDir+DY5to50_incl+"_histos.root"],
+        #            "relativeWeight" : DY5to50_incl_db.source_dataset.xsection/DY5to50_incl_db.event_weight_sum
+        #        },
         "DY5to50_HT100to200" : { 
                     "files" : [inFileDir+DY5to50_HT100to200+"_histos.root"],
                     "relativeWeight" : DY5to50_HT100to200_db.source_dataset.xsection/DY5to50_HT100to200_db.event_weight_sum
@@ -140,20 +140,19 @@ MVAmethods = ["kBDT"]
 weightExpr = "event_weight * trigeff * jjbtag * llidiso * pu"
 
 if __name__ == '__main__':
+
+    sigFiles = {}
     
     for node in nodes:
             
-        sigFiles = {
-                        node: 
-                        {
+        sigFiles[node] = {
                             "files" : [ inFileDir + "GluGluToHHTo2B2VTo2L2Nu_node_{}_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root".format(node) ],
                             "relativeWeight" : 1.
                         }
-                    }
             
-        label = label_template.replace("DATE", date).replace("NODE", node).replace("SUFFIX", suffix)
+    label = label_template.replace("DATE", date).replace("NODE", "all").replace("SUFFIX", suffix)
         
-        print bkgFiles, sigFiles
+    print bkgFiles, sigFiles
         
-        trainMVA(bkgFiles, sigFiles, discriList, cut, weightExpr, MVAmethods, spectatorList, label)
+    trainMVA(bkgFiles, sigFiles, discriList, cut, weightExpr, MVAmethods, spectatorList, label)
 

--- a/plotIt_hh/DataFiles.yml
+++ b/plotIt_hh/DataFiles.yml
@@ -1,14 +1,14 @@
-#'DoubleEG_Run2015D-16Dec2015-v2_2016-03-03_v0.1.0+76X_HHAnalysis_2016-04-04.v0_histos.root':
-#  type: data
-#  #legend: "Data"
-#  group: "Data"
-#
-#'DoubleMuon_Run2015D-16Dec2015-v1_2016-03-03_v0.1.0+76X_HHAnalysis_2016-04-04.v0_histos.root':
-#  type: data
-#  legend: "Data"
-#  group: "Data"
-#
-#'MuonEG_Run2015D-16Dec2015-v1_2016-03-03_v0.1.0+76X_HHAnalysis_2016-04-04.v0_histos.root':
-#  type: data
-#  #legend: "Data"
-#  group: "Data"
+'DoubleMuon_Run2015D-16Dec2015-v1_2016-03-03_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: data
+  #legend: "Data"
+  group: "Data"
+
+'DoubleEG_Run2015D-16Dec2015-v2_2016-03-03_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: data
+  #legend: "Data"
+  group: "Data"
+
+'MuonEG_Run2015D-16Dec2015-v1_2016-03-03_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: data
+  #legend: "Data"
+  group: "Data"

--- a/plotIt_hh/MCFiles.yml
+++ b/plotIt_hh/MCFiles.yml
@@ -160,82 +160,73 @@
 
 # DY
 
-#'DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1327_plus_1405_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1394_plus_1325_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1328_plus_1418_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1332_plus_1331_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1397_plus_1398_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1392_plus_1326_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1395_plus_1419_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-#
-#'DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_1402_plus_1329_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#LO
+'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+#'DYJetsToLL_M-5to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
 #  group: DY
 #  order: 7
 
-#'DY-M-5toInfHadded.root':
-#  type: mc
-#  group: DY
-#  order: 7
+'DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
 
-#'DY-M-5toInfonlyHT.root':
-#  type: mc
-#  group: DY
-#  order: 7
+'DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
   
-#'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+# NLO
+#'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext3_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
 #  group: DY
 #  order: 7
 #
-#'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext4_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
 #  group: DY
 #  order: 7
-
-'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext3_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext4_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
 
 # Signal, non-resonant
 
 'GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: signal
   cross-section: 10000
-  #generated-events: 300000
   line-color: '#008A00'
   legend: 'SM'
   legend-order: 5
@@ -245,8 +236,7 @@
 'GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: signal
   cross-section: 10000
-  #generated-events: 300000
-  line-color: '#00ABA9'
+  line-color: '#F0A30A'
   legend: 'Box'
   legend-order: 5
   line-width: 2
@@ -255,7 +245,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#FA6800'
 #  legend: 'BM2'
 #  legend-order: 5
@@ -265,7 +254,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#E51400'
 #  legend: 'BM3'
 #  legend-order: 5
@@ -275,7 +263,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#A20025'
 #  legend: 'BM4'
 #  legend-order: 5
@@ -285,7 +272,6 @@
 'GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: signal
   cross-section: 10000
-  #generated-events: 300000
   line-color: '#0050EF'
   legend: 'BM5'
   legend-order: 5
@@ -295,9 +281,8 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
-#  line-color: '#AA00FF'
 #  legend: 'BM6'
+#  line-color: '#A4C500'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
@@ -305,7 +290,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#D80073'
 #  legend: 'BM7'
 #  legend-order: 5
@@ -315,8 +299,7 @@
 'GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: signal
   cross-section: 10000
-  #generated-events: 300000
-  line-color: '#A4C500'
+  line-color: '#AA00FF'
   legend: 'BM8'
   legend-order: 5
   line-width: 2
@@ -325,8 +308,7 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
-#  line-color: '#F0A30A'
+#  line-color: '#00ABA9'
 #  legend: 'BM9'
 #  legend-order: 5
 #  line-width: 2
@@ -335,7 +317,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#825A2C'
 #  legend: 'BM10'
 #  legend-order: 5
@@ -345,7 +326,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#6D8764'
 #  legend: 'BM11'
 #  legend-order: 5
@@ -355,7 +335,6 @@
 #'GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  #generated-events: 300000
 #  line-color: '#647687'
 #  legend: 'BM12'
 #  legend-order: 5
@@ -365,7 +344,6 @@
 'GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: signal
   cross-section: 10000
-  #generated-events: 300000
   line-color: '#76608A'
   legend: 'BM13'
   legend-order: 5

--- a/plotIt_hh/MCFiles.yml
+++ b/plotIt_hh/MCFiles.yml
@@ -135,23 +135,23 @@
 #  group: tt
 #  order: 8
 
-'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'TT_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: tt
+#  order: 8
+
+'TT_FL_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
   type: mc
   group: tt
   order: 8
-
-#'TT_FL_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: tt
-#  order: 8
-#'TT_SL_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: tt
-#  order: 8
-#'TT_FH_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: tt
-#  order: 8
+'TT_SL_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: tt
+  order: 8
+'TT_FH_TuneCUETP8M1_13TeV-powheg-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: tt
+  order: 8
 
 #'TTTo2L2Nu_13TeV-powheg_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
@@ -160,192 +160,206 @@
 
 # DY
 
-#LO
-'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-#'DYJetsToLL_M-5to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: mc
-#  group: DY
-#  order: 7
-
-'DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-
-'DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: mc
-  group: DY
-  order: 7
-  
-# NLO
-#'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext3_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+##LO
+#'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
 #  group: DY
 #  order: 7
 #
-#'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext4_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'DYJetsToLL_M-50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
 #  type: mc
 #  group: DY
 #  order: 7
+#
+#'DYJetsToLL_M-50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+#'DYJetsToLL_M-50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+#'DYJetsToLL_M-50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+##'DYJetsToLL_M-5to50_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+##  type: mc
+##  group: DY
+##  order: 7
+#
+#'DYJetsToLL_M-5to50_HT-100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+#'DYJetsToLL_M-5to50_HT-200to400_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+#'DYJetsToLL_M-5to50_HT-400to600_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_Fall15MiniAODv2_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+#
+#'DYJetsToLL_M-5to50_HT-600toInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8_extended_ext0_plus_ext1_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#  type: mc
+#  group: DY
+#  order: 7
+  
+# NLO
+'DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext3_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
+
+'DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8_extended_ext0_plus_ext1_plus_ext4_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+  type: mc
+  group: DY
+  order: 7
 
 # Signal, non-resonant
 
-'GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+'GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
   type: signal
-  cross-section: 10000
-  line-color: '#008A00'
+  cross-section: 1000
+  line-color: '#006600'
+  #line-color: '#008A00'
   legend: 'SM'
   legend-order: 5
   line-width: 2
   line-type: 1
 
-'GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-  type: signal
-  cross-section: 10000
-  line-color: '#F0A30A'
-  legend: 'Box'
-  legend-order: 5
-  line-width: 2
-  line-type: 1
-
-#'GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_box_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#FA6800'
-#  legend: 'BM2'
+#  line-color: '#000000'
+#  #line-color: '#F0A30A'
+#  legend: 'Box'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
 #
-#'GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_1_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#E51400'
+#  line-color: '#FF6600'
+#  #line-color: '#76608A'
+#  legend: 'BM1'
+#  legend-order: 5
+#  line-width: 2
+#  line-type: 1
+
+'GluGluToHHTo2B2VTo2L2Nu_node_2_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
+  type: signal
+  cross-section: 1000
+  line-color: '#FFCC00'
+  #line-color: '#FA6800'
+  legend: 'BM2'
+  legend-order: 5
+  line-width: 2
+  line-type: 1
+
+#'GluGluToHHTo2B2VTo2L2Nu_node_3_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
+#  type: signal
+#  cross-section: 10000
+#  line-color: '#FF0000'
+#  #line-color: '#E51400'
 #  legend: 'BM3'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
 #
-#'GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_4_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#A20025'
+#  line-color: '#00DC00'
+#  #line-color: '#A20025'
 #  legend: 'BM4'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
 
-'GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+'GluGluToHHTo2B2VTo2L2Nu_node_5_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
   type: signal
-  cross-section: 10000
-  line-color: '#0050EF'
+  cross-section: 1000
+  line-color: '#006666'
+  #line-color: '#0050EF'
   legend: 'BM5'
   legend-order: 5
   line-width: 2
   line-type: 1
 
-#'GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: signal
-#  cross-section: 10000
-#  legend: 'BM6'
-#  line-color: '#A4C500'
-#  legend-order: 5
-#  line-width: 2
-#  line-type: 1
-#
-#'GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: signal
-#  cross-section: 10000
-#  line-color: '#D80073'
-#  legend: 'BM7'
-#  legend-order: 5
-#  line-width: 2
-#  line-type: 1
-
-'GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+'GluGluToHHTo2B2VTo2L2Nu_node_6_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
   type: signal
-  cross-section: 10000
-  line-color: '#AA00FF'
-  legend: 'BM8'
+  cross-section: 1000
+  legend: 'BM6'
+  line-color: '#0066FF'
+  #line-color: '#A4C500'
   legend-order: 5
   line-width: 2
   line-type: 1
 
-#'GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_7_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#00ABA9'
+#  line-color: '#000099'
+#  #line-color: '#D80073'
+#  legend: 'BM7'
+#  legend-order: 5
+#  line-width: 2
+#  line-type: 1
+#
+#'GluGluToHHTo2B2VTo2L2Nu_node_8_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
+#  type: signal
+#  cross-section: 10000
+#  line-color: '#9900CC'
+#  #line-color: '#AA00FF'
+#  legend: 'BM8'
+#  legend-order: 5
+#  line-width: 2
+#  line-type: 1
+#
+#'GluGluToHHTo2B2VTo2L2Nu_node_9_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
+#  type: signal
+#  cross-section: 10000
+#  line-color: '#FF0099'
+#  #line-color: '#00ABA9'
 #  legend: 'BM9'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
 #
-#'GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_10_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#825A2C'
+#  line-color: '#FF66FF'
+#  #line-color: '#825A2C'
 #  legend: 'BM10'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
 #
-#'GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+#'GluGluToHHTo2B2VTo2L2Nu_node_11_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
 #  type: signal
 #  cross-section: 10000
-#  line-color: '#6D8764'
+#  line-color: '#666666'
+#  #line-color: '#6D8764'
 #  legend: 'BM11'
 #  legend-order: 5
 #  line-width: 2
 #  line-type: 1
-#
-#'GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
-#  type: signal
-#  cross-section: 10000
-#  line-color: '#647687'
-#  legend: 'BM12'
-#  legend-order: 5
-#  line-width: 2
-#  line-type: 1
 
-'GluGluToHHTo2B2VTo2L2Nu_node_13_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root':
+'GluGluToHHTo2B2VTo2L2Nu_node_12_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root':
   type: signal
-  cross-section: 10000
-  line-color: '#76608A'
-  legend: 'BM13'
+  cross-section: 1000
+  line-color: '#00FFFF'
+  #line-color: '#647687'
+  legend: 'BM12'
   legend-order: 5
   line-width: 2
   line-type: 1

--- a/plotIt_hh/centralConfig.yml
+++ b/plotIt_hh/centralConfig.yml
@@ -9,7 +9,7 @@ extra-label: "Preliminary"
 # SKIM
 #root: '/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/CommonTools/histFactory/hists_skimmed_btagMM_bdtCut_2016_01_17/'
 
-root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160525_0/condor/output/'
+root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160602_BDT_all_0/condor/output/'
 
 luminosity: 2300  # according to brilcalc 
 luminosity-error: 0.027

--- a/plotIt_hh/centralConfig.yml
+++ b/plotIt_hh/centralConfig.yml
@@ -9,7 +9,7 @@ extra-label: "Preliminary"
 # SKIM
 #root: '/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/CommonTools/histFactory/hists_skimmed_btagMM_bdtCut_2016_01_17/'
 
-root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160602_BDT_all_0/condor/output/'
+root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160609_reweight_2/condor/output/'
 
 luminosity: 2300  # according to brilcalc 
 luminosity-error: 0.027

--- a/plotIt_hh/legendPosition.yml
+++ b/plotIt_hh/legendPosition.yml
@@ -1,6 +1,6 @@
 position: [0.61, 0.61, 0.94, 0.89]
 entries:
   -
-    label: 'Signal (10 pb)'
+    label: 'Signal (1 pb)'
     type: signal
     order: 1000  # Always on top

--- a/plotIt_hh/listHistos.py
+++ b/plotIt_hh/listHistos.py
@@ -16,7 +16,7 @@ parser.add_argument('--mjj', help='Use if you want to produce plots related to M
 args = parser.parse_args()
 
 baseDir = "/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/"
-fileName = baseDir + args.directory + "/condor/output/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph_v0.1.2+76X_HHAnalysis_2016-05-02.v0_histos.root"
+fileName = baseDir + args.directory + "/condor/output/GluGluToHHTo2B2VTo2L2Nu_node_SM_13TeV-madgraph_v0.1.3+76X_HHAnalysis_2016-06-03.v0_histos.root"
 
 skim = False
 

--- a/treeFactory_hh/generateTrees.py
+++ b/treeFactory_hh/generateTrees.py
@@ -6,17 +6,18 @@ scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe
 sys.path.append(scriptDir)
 sys.path.append(os.path.join(scriptDir, "../histFactory_hh"))
 from basePlotter import *
-#includes = ["/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/histFactory_hh/readMVA.h"]
+includes = ["/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/histFactory_hh/readMVA.h"]
 
 plots = []
 
 # llbb 
-basePlotter = BasePlotter(mode = "custom", baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = "nominal")
+basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = "nominal")
 weights_llbb = []
 flavour = "All"
 categories_llbb = [flavour]
 stage_llbb = "no_cut"
 plots_llbb = ["mll", "mjj", "basic", "bdtinput", "ht", "other", "llidisoWeight", 'jjbtagWeight', 'trigeffWeight', 'puWeight', 'forSkimmer', 'csv']
+plots_llbb += ["bdtoutput"]
 plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = "nominal", weights = weights_llbb, requested_plots = plots_llbb))
 
 tree = {}

--- a/treeFactory_hh/generateTrees.py
+++ b/treeFactory_hh/generateTrees.py
@@ -6,9 +6,26 @@ scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe
 sys.path.append(scriptDir)
 sys.path.append(os.path.join(scriptDir, "../histFactory_hh"))
 from basePlotter import *
-includes = ["/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/histFactory_hh/readMVA.h"]
 
 plots = []
+includes = []
+code_before_loop = ""
+
+# Needed to evaluate MVA outputs
+includes.append( os.path.join(scriptDir, "..", "common", "readMVA.h") )
+
+# For cluster reweighting
+includes.append( os.path.join(scriptDir, "..", "common", "reweight_v1tov3.h") )
+
+code_before_loop += """
+getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_8_0_6/src/cp3_llbb/HHTools/scripts/", 0, 11);
+"""
+
+sample_weights = {}
+for node in range(1, 13):
+    sample_weights[ "cluster_node_" + str(node) ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
+
+# Plot configuration
 
 # llbb 
 basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = "nominal")
@@ -17,7 +34,7 @@ flavour = "All"
 categories_llbb = [flavour]
 stage_llbb = "no_cut"
 plots_llbb = ["mll", "mjj", "basic", "bdtinput", "ht", "other", "llidisoWeight", 'jjbtagWeight', 'trigeffWeight', 'puWeight', 'forSkimmer', 'csv']
-plots_llbb += ["bdtoutput"]
+#plots_llbb += ["bdtoutput"]
 plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = "nominal", weights = weights_llbb, requested_plots = plots_llbb))
 
 tree = {}


### PR DESCRIPTION
What's needed to reweight v1 to v3 samples on-the-fly in histFactory and treeFactory: a class is defined in file `common/reweight_v1tov3.h`, which is included in the plotter/skimmer. 
A static instance of the class then handles retrieving the weights file and return the weight based on the mhh and cos given.
(It was necessary to make it static since there is no communication between the `plot()` or `skim()` functions and the `getSampleWeight()` function).
