### PR TITLE
Latest update

### DIFF
--- a/histFactory_hh/basePlotter.py
+++ b/histFactory_hh/basePlotter.py
@@ -44,13 +44,16 @@ class BasePlotter:
         
         # The following will need to be modified each time the name of the BDT output changes
         bdtNameTemplate = "DATE_BDT_NODE_SUFFIX"
+        
         # v1 benchmark BDTs (w/ LO DY)
         #date = "2016_05_27"
         #nodes = ["SM", "box", "5", "8", "13", "all"]
+        
         # v3 benchmark BDTs (w/ NLO DY)
         date = "2016_06_10"
-        #nodes = ["SM", "2", "5", "6", "12", "all"]
-        nodes = ["SM", "2"] # Chosen BDTs
+        nodes = ["SM", "2", "5", "6", "12", "all"]
+        #nodes = ["SM", "2"] # Chosen BDTs
+        
         suffixes = ["VS_TT_DYHTonly_tW_8var"]
         BDToutputs = {}
         bdtNames = []
@@ -168,7 +171,7 @@ class BasePlotter:
 
         # Append the proper extension to the name plot if needed (scale name are down at the end of the code)
         self.systematicString = ""
-        if not systematic == "nominal" and not systematic == "scale":
+        if not systematic == "nominal" and not "scale" in systematic:
             self.systematicString = "__" + systematic
 
         available_weights = {'trigeff' : trigEff, 'jjbtag' : jjBtag_sf, 'llidiso' : llIdIso_sf, 'pu' : puWeight}
@@ -936,17 +939,23 @@ class BasePlotter:
             ])
 
         plotsToReturn = []
+        
         for plotFamily in requested_plots:
+            
             if "scale" in systematic:
+                
                 scaleIndices = ["0", "1", "2", "3", "4", "5"]
+                
                 for scaleIndice in scaleIndices:
+                    
                     scaleWeight = "event_scale_weights[%s]" % scaleIndice
+                    
                     for plot in getattr(self, plotFamily+"_plot"):
                         tempPlot = copy.deepcopy(plot)
                         # Two different ways to normalise the variations
                         if "Uncorr" not in systematic:
                             tempPlot["normalize-to"] = "scale_%s" % scaleIndice
-                        tempPlot["name"] += "__scale%s"%scaleIndice
+                        tempPlot["name"] += "__" + systematic + scaleIndice
                         if not "Weight" in plotFamily:
                             tempPlot["weight"] = "event_weight" + " * " + scaleWeight
                             for weight in weights:
@@ -954,7 +963,9 @@ class BasePlotter:
                         else:
                             print "No other weight than event_weight for ", plotFamily 
                         plotsToReturn.append(tempPlot)
+            
             elif "pdf" in systematic:
+                
                 for plot in getattr(self, plotFamily+"_plot"):
                     if not "Weight" in plotFamily:
                         plot["weight"] = "event_weight" + " * " + pdfWeight
@@ -964,7 +975,9 @@ class BasePlotter:
                     else:
                         print "No other weight than event_weight for ", plotFamily 
                     plotsToReturn.append(plot)
+            
             else:
+                
                 for plot in getattr(self, plotFamily+"_plot"):
                     if not "Weight" in plotFamily:
                         plot["weight"] = "event_weight"

--- a/histFactory_hh/generatePlots.py
+++ b/histFactory_hh/generatePlots.py
@@ -7,6 +7,27 @@ sys.path.append(scriptDir)
 from basePlotter import *
 from HHAnalysis import HH
 
+
+def getBinningStrWithMax(nBins, start, end, max):
+    """Return string defining a binning in histFactory, with 'nBins' bins between
+    'start' and 'end', but with the upper edge replaced by 'max'."""
+    
+    bins = [start]
+    pos = start
+    for i in range(nBins):
+        pos += (end-start)/nBins
+        bins.append(pos)
+    if bins[-1] < max:
+        bins[-1] = max
+
+    m_string = str(len(bins)-1) + ", { "
+    for b in bins[0:len(bins)-1]:
+        m_string += str(b) + ", "
+    m_string += str(bins[-1]) + "}"
+
+    return m_string
+
+
 includes = []
 plots = []
 code_before_loop = ""
@@ -20,6 +41,7 @@ includes.append( os.path.join(scriptDir, "..", "common", "reweight_v1tov3.h") )
 code_before_loop += """
 getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_8_0_6/src/cp3_llbb/HHTools/scripts/", 0, 11);
 """
+## For v1->v1 checks:
 #code_before_loop += """
 #getBenchmarkReweighter("/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/scripts/", 2, 13);
 #"""
@@ -27,6 +49,7 @@ getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_8_0_6/src/cp
 sample_weights = {}
 for node in range(1, 13):
     sample_weights[ "cluster_node_" + str(node) ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
+## For v1->v1 checks:
 #for node in range(2, 14):
 #    sample_weights[ "cluster_node_rwgt_" + str(node) ] = "getBenchmarkReweighter().getWeight({}, hh_gen_mHH, hh_gen_costhetastar)".format(node)
 
@@ -46,33 +69,33 @@ plots_llbb = plots_lljj
 #plots_llbb = ["bdtinput", "mjj"]
 
 #systematics = {"modifObjects" : ["nominal"]}
-systematics = {"modifObjects" : ["nominal", "jecup", "jecdown", "jerup", "jerdown"], "SF" : ["elidisoup", "elidisodown", "muidup", "muiddown", "muisoup", "muisodown", "jjbtagup", "jjbtagdown", "puup", "pudown", "trigeffup", "trigeffdown", "pdfup", "pdfdown", "scale", "saleUncorr"]}
+systematics = {"modifObjects" : ["nominal", "jecup", "jecdown", "jerup", "jerdown"], "SF" : ["elidisoup", "elidisodown", "muidup", "muiddown", "muisoup", "muisodown", "jjbtagup", "jjbtagdown", "puup", "pudown", "trigeffup", "trigeffdown", "pdfup", "pdfdown", "scale", "scaleUncorr"]}
 #systematics = {"modifObjects" : ["nominal"], "SF" : ["scale"]}
 
 # Define binning of 2D templates for fitting
 chosen2Dbinnings = {
         "3x25": {
-            "mjjBinning": "3, { 0, 75, 140, 6000 }",
+            "mjjBinning": "3, { 0, 75, 140, 13000 }",
             "bdtNbins": 25
         },
         "25x25": {
-            "mjjBinning": "25, 0, 600",
+            "mjjBinning": getBinningStrWithMax(25, 0, 600, 13000), 
             "bdtNbins": 25
         },
         "20x20": {
-            "mjjBinning": "20, 0, 600",
+            "mjjBinning": getBinningStrWithMax(20, 0, 600, 13000), 
             "bdtNbins": 20
         },
         "10x10": {
-            "mjjBinning": "10, 0, 600",
+            "mjjBinning": getBinningStrWithMax(10, 0, 600, 13000), 
             "bdtNbins": 10
         },
         "10x25": {
-            "mjjBinning": "10, 0, 600",
+            "mjjBinning": getBinningStrWithMax(10, 0, 600, 13000), 
             "bdtNbins": 25
         },
         "5x25": {
-            "mjjBinning": "5, 0, 600",
+            "mjjBinning": getBinningStrWithMax(5, 0, 600, 13000), 
             "bdtNbins": 25
         },
     }
@@ -91,23 +114,22 @@ for systematicType in systematics.keys():
         #plots.extend(basePlotter_lljj.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
         #plots.extend(basePlotter_lljj.generatePlots(["MuMu", "ElEl", "MuEl"], stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = ["mll"]))
         
-        #plots.extend(basePlotter_lljj.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = ["scaleWeight", "mll", "mjj"]))
- 
         
         ## llbb 
         basePlotter_llbb = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = objects)
-        
+       
+        ## No mll cut
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         #plots.extend(basePlotter_llbb.generatePlots(["MuMu", "ElEl", "MuEl"], stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = ["mll"]))
         
+        ## With mll cut
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput", "mjj", "mjj_vs_bdt"], fit2DtemplatesBinning = chosen2Dbinnings))
         
-        #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = ["scaleWeight", "mll", "mjj"]))
-        #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = ["scaleWeight", "mll", "mjj", "bdtoutput"]))
-        
+        ## With mll cut + actually cut into mjj sidebands
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mjj_blind", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mjj_blind", systematic = systematic, weights = weights_llbb, requested_plots = ["bdtoutput"]))
         
+        ## With mll cut + select into high-BDT regions
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "highBDT_node_SM", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         #plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "highBDT_node_2", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))

--- a/histFactory_hh/launchHistFactory.py
+++ b/histFactory_hh/launchHistFactory.py
@@ -187,7 +187,7 @@ if args.test:
 
 samples = []
 for ID in IDs + IDsToSplitMore:
-    filesperJob = 20
+    filesperJob = 15
     if ID in IDsToSplitMore:
         filesperJob = 1
     samples.append(
@@ -280,6 +280,7 @@ if args.filter:
 
         # Handle the cluster v1tov3 reweighting
         if "all_nodes" in sample["db_name"]:
+            ## For v1->v1 reweighting check:
             #for node in range(2, 14):
             #    node_str = "node_rwgt_" + str(node)
             for node in range(1, 13):

--- a/plotIt_hh/centralConfig.yml
+++ b/plotIt_hh/centralConfig.yml
@@ -4,16 +4,12 @@ luminosity-label: '%1$.2f fb^{-1} (13 TeV)'
 experiment: "CMS"
 extra-label: "Preliminary"
 
-# NTUPLE
-#root: '/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/HHTools/histFactory_hh/76_mjjStudy/condor/output/'
-# SKIM
-#root: '/home/fynu/bfrancois/scratch/framework/oct2015/CMSSW_7_4_15/src/cp3_llbb/CommonTools/histFactory/hists_skimmed_btagMM_bdtCut_2016_01_17/'
-
 #root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160611_all_0/condor/output/'
 #root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160614_mllFlav_0/condor/output/'
 #root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160614_highBDT_2D_0/condor/output/'
 #root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160615_allGood_0/condor/output/'
 root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160622_allGood_scaleNoNorm_0/condor/output/'
+#root: '/home/fynu/swertz/scratch/CMSSW_7_6_3_patch2/src/cp3_llbb/HHTools/condor/160624_new2Dbinnings_0/condor/output/'
 
 luminosity: 2300  # according to brilcalc 
 luminosity-error: 0.027

--- a/plotIt_hh/hh_plotter_all.yml
+++ b/plotIt_hh/hh_plotter_all.yml
@@ -22,5 +22,5 @@ systematics:
   - jec
   - jer 
   - trigeff
-  - scale
+  - scaleUncorr
   - pdf

--- a/plotIt_hh/listHistos.py
+++ b/plotIt_hh/listHistos.py
@@ -47,7 +47,8 @@ defaultStyle_events.update({
         'y-axis': 'Events',
         'y-axis-format': '%1% / %2$.2f',
         })
-print args
+
+nHistos = 0
 
 for key in keys:
     if key.GetName() not in alreadyIn and not "__" in key.GetName():
@@ -65,9 +66,10 @@ for key in keys:
         #if "highBDT" in key.GetName(): continue
         #if "highBDT" not in key.GetName(): continue
         #if "_vs_" not in key.GetName(): continue
+        #if "3x25" not in key.GetName(): continue
 
-        #if "ll_M" not in key.GetName() or "All" not in key.GetName(): continue
-        if "ll_M" in key.GetName() and "All" not in key.GetName(): continue
+        #if "ll_M" not in key.GetName() or "All" in key.GetName(): continue
+        #if "ll_M" in key.GetName() and "All" not in key.GetName(): continue
 
         ## Update all the plots with title, ...
 
@@ -246,19 +248,31 @@ for key in keys:
             plot['x-axis'] = "BDT output, m_{jj} bins"
             plot.update(defaultStyle_events)
             
-            if "3x25" in key.GetName():
+            if "3x25" in key.GetName() and "BDT_2" in key.GetName():
                 plot['vertical-lines'] = [ 
                         { "line-color": 1, "line-type": 2, "line-width": 2, "value": 0.6 }, 
-                        { "line-color": 1, "line-type": 2, "line-width": 2, "value": 1.8 }
+                        { "line-color": 1, "line-type": 2, "line-width": 2, "value": 1.7 }
                     ]
+                plot['y-axis-range'] = [0.01, 450]
+                if not args.unblinded and "blind" not in key.GetName():
+                    plot['blinded-range'] = [1.128, 1.7]
+        
+            if "3x25" in key.GetName() and "BDT_SM" in key.GetName():
+                plot['vertical-lines'] = [ 
+                        { "line-color": 1, "line-type": 2, "line-width": 2, "value": 0.5 }, 
+                        { "line-color": 1, "line-type": 2, "line-width": 2, "value": 1.5 }
+                    ]
+                plot['y-axis-range'] = [0.01, 400]
+                if not args.unblinded and "blind" not in key.GetName():
+                    plot['blinded-range'] = [1, 1.5]
+
+            if "3x25" in key.GetName():
                 plot['labels'] += [
                         { "size": 18, "position": [ 0.23, 0.65 ], "text": "m_{jj} < 75 GeV" },
-                        { "size": 18, "position": [ 0.475, 0.735 ], "text": "m_{jj} #in [75, 140[ GeV" },
-                        { "size": 18, "position": [ 0.75, 0.8 ], "text": "m_{jj} #geq 140 GeV" },
+                        { "size": 18, "position": [ 0.475, 0.735 ], "text": "75 GeV #leq m_{jj} < 140 GeV" },
+                        { "size": 18, "position": [ 0.75, 0.82 ], "text": "m_{jj} #geq 140 GeV" },
                     ]
-                if not args.unblinded and "blind" not in key.GetName():
-                    plot['blinded-range'] = [1.177, 1.8]
-        
+
         # Default:
         
         else:
@@ -313,5 +327,11 @@ for key in keys:
                 }]
             plot['legend-position'] = [0.22, 0.61, 0.62, 0.89]
 
+        # Finally, save what we have
+        plots[key.GetName()] = plot
+        nHistos += 1
+
 with open("allPlots.yml", "w") as f:
     yaml.dump(plots, f)
+
+print "Saved configuration for {} plots in {}".format(nHistos, "allPlots.yml")


### PR DESCRIPTION
More updates...

When producing histograms, after hadd'ing the output the results have to be flattened first (using `flattenTH2.py histfactory_output/condor/output/* -r '.*_vs_.*' -a x`), and then `createScaleSystematics.py` has to be called twice (once with `-s scale` and once with `-s scaleUncorr`) to get all the envelopes.
