### PR TITLE
Fill only no-btag histograms with nobtag -> btagM weights if running over DY

### DIFF
--- a/histFactory_hh/basePlotter.py
+++ b/histFactory_hh/basePlotter.py
@@ -38,7 +38,7 @@ def default_headers():
             ]
 
 class BasePlotter:
-    def __init__(self, baseObjectName = "hh_llmetjj_allTight_btagM_csv", btagWP_str = 'medium', objects = "nominal", WP = ["T", "T", "T", "T", "L", "L", "M", "M", "csv"]):
+    def __init__(self, baseObjectName, btagWP_str, objects="nominal"):
         # systematic should be jecup, jecdown, jerup or jerdown. The one for lepton, btag, etc, have to be treated with the "weight" parameter in generatePlots.py (so far)
 
         self.baseObject = baseObjectName+"[0]"
@@ -69,7 +69,7 @@ class BasePlotter:
         self.jet2_fwkIdx = self.jet2_str+".idx"
 
         # Ensure we have one candidate, works also for jecup etc
-        self.sanityCheck = "Length$(%s)>0"%baseObjectName
+        self.sanityCheck = "Length$(%s)>0" % baseObjectName
 
         # Categories (lepton flavours)
         self.dict_cat_cut =  {
@@ -95,12 +95,14 @@ class BasePlotter:
     def get_code_after_loop(self):
         return self.code_after_loop
     
-    def generatePlots(self, categories = ["All"], stage = "cleaning_cut", requested_plots = [], weights = ['trigeff', 'jjbtag', 'llidiso', 'pu'], extraCut = "", systematic = "nominal", extraString = "", fit2DtemplatesBinning = None):
+    def generatePlots(self, categories, stage, requested_plots, weights, systematic="nominal", extraString="", fit2DtemplatesBinning=None, prependCuts=[], appendCuts=[]):
 
         # Protect against the fact that data do not have jecup collections, in the nominal case we still have to check that data have one candidate 
         sanityCheck = self.sanityCheck
         if systematic != "nominal":
             sanityCheck = self.joinCuts("!event_is_data", self.sanityCheck)
+
+        cuts = self.joinCuts(*(prependCuts + [sanityCheck]))
 
         # Possible stages (selection)
         # FIXME: Move to constructor
@@ -304,7 +306,7 @@ class BasePlotter:
         for cat in categories:
 
             catCut = self.dict_cat_cut[cat]
-            self.totalCut = self.joinCuts(sanityCheck, catCut, extraCut, dict_stage_cut[stage])
+            self.totalCut = self.joinCuts(cuts, catCut, dict_stage_cut[stage], *appendCuts)
             self.llFlav = cat
             self.extraString = stage + extraString
 

--- a/histFactory_hh/basePlotter.py
+++ b/histFactory_hh/basePlotter.py
@@ -1076,7 +1076,14 @@ class BasePlotter:
                     'variable': "event_run",
                     'plot_cut': self.totalCut,
                     'binning': '(300, 0, 300000)'
-                }
+                },
+                {
+                    'name': 'isSF_%s_%s_%s%s' % (self.llFlav, self.suffix, self.extraString, self.systematicString),
+                    'variable': self.baseObject + ".isSF",
+                    'plot_cut': self.totalCut,
+                    'binning': '(2, 0, 2)',
+                    'type': 'bool'
+                },
             ])
 
         plotsToReturn = []

--- a/histFactory_hh/generatePlots.py
+++ b/histFactory_hh/generatePlots.py
@@ -110,7 +110,6 @@ include_directories.append(os.path.join(scriptDir, "..", "common"))
 weights_lljj = ['trigeff', 'llidiso', 'pu']
 # categories_lljj = ["All", "MuMu", "ElEl", "MuEl"] 
 categories_lljj = ["All"] 
-stage_lljj = "no_cut"
 plots_lljj = ["mll", "mjj", "basic", "csv", "bdtinput", "evt"]
 
 # Weights
@@ -119,7 +118,6 @@ plots_lljj = ["mll", "mjj", "basic", "csv", "bdtinput", "evt"]
 #llbb
 weights_llbb = ['trigeff', 'llidiso', 'pu', 'jjbtag_heavy', 'jjbtag_light']
 categories_llbb = ["All"]
-stage_llbb = "no_cut"
 plots_llbb = plots_lljj + ["resonant_nnoutput"]
 #plots_llbb = ["bdtinput", "mjj"]
 
@@ -146,19 +144,20 @@ for systematicType in systematics.keys():
         ## lljj 
         basePlotter_lljj = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = objects)
         
-        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, stage_lljj, systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
+        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "no_cut", systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
         plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "mll_cut", systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
         plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "inverted_mll_cut", systematic = systematic, weights = weights_lljj, requested_plots = plots_lljj))
 
-        # mll < 76 + no btag -> btagM reweighting applied
-        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "mll_cut", systematic = systematic, weights = weights_lljj + ['dy_nobtag_to_btagM'], requested_plots = plots_lljj + ['DYNobtagToBTagMWeight'], extraString='_with_nobtag_to_btagM_reweighting'))
-        # mll > 76 + no btag -> btagM reweighting applied
-        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "inverted_mll_cut", systematic = systematic, weights = weights_lljj + ['dy_nobtag_to_btagM'], requested_plots = plots_lljj + ['DYNobtagToBTagMWeight'], extraString='_with_nobtag_to_btagM_reweighting'))
+        # mll < 76 + no btag -> btagM reweighting applied ; only for DY
+        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "mll_cut", systematic=systematic, weights=weights_lljj + ['dy_nobtag_to_btagM'], requested_plots=plots_lljj + ['resonant_nnoutput', 'DYNobtagToBTagMWeight'], extraString='_with_nobtag_to_btagM_reweighting', prependCuts=['isDY']))
+        # mll > 76 + no btag -> btagM reweighting applied ; only for DY
+        plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "inverted_mll_cut", systematic = systematic, weights = weights_lljj + ['dy_nobtag_to_btagM'], requested_plots = plots_lljj + ['resonant_nnoutput', 'DYNobtagToBTagMWeight'], extraString='_with_nobtag_to_btagM_reweighting', prependCuts=['isDY']))
 
         # # mll < 76 + b-tagging effiency applied
         # plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "mll_cut", systematic = systematic, weights = weights_lljj + ['twoB_eff'], requested_plots = plots_lljj, extraString='_with_btag_eff'))
         # # mll > 76 + btagging efficiency applied
         # plots.extend(basePlotter_lljj.generatePlots(categories_lljj, "inverted_mll_cut", systematic = systematic, weights = weights_lljj + ['twoB_eff'], requested_plots = plots_lljj, extraString='_with_btag_eff'))
+
 
         code_in_loop += basePlotter_lljj.get_code_in_loop()
         code_before_loop += basePlotter_lljj.get_code_before_loop()
@@ -167,7 +166,7 @@ for systematicType in systematics.keys():
         ## llbb 
         basePlotter_llbb = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = objects)
        
-        plots.extend(basePlotter_llbb.generatePlots(categories_llbb, stage_llbb, systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
+        plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "no_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
         plots.extend(basePlotter_llbb.generatePlots(categories_llbb, "inverted_mll_cut", systematic = systematic, weights = weights_llbb, requested_plots = plots_llbb))
 

--- a/treeFactory_hh/TreesDefinition.py
+++ b/treeFactory_hh/TreesDefinition.py
@@ -1,0 +1,48 @@
+import ROOT as R
+import copy, sys, os, inspect 
+
+scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+sys.path.append(scriptDir)
+sys.path.append(os.path.join(scriptDir, "../histFactory_hh"))
+
+from basePlotter import *
+
+include_directories = []
+plots = []
+library_directories = []
+libraries = []
+
+include_directories.append(os.path.join(scriptDir, "..", "common"))
+
+headers = default_headers()
+
+code_before_loop = default_code_before_loop()
+code_in_loop = default_code_in_loop()
+code_after_loop = default_code_after_loop()
+
+sample_weights = {}
+# for node in range(1, 13):
+    # sample_weights[ "cluster_node_" + str(node) ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
+
+# Plot configuration
+
+weights_llbb = []
+flavour = "All"
+categories_llbb = [flavour]
+stage_llbb = "no_cut"
+plots_llbb = ["mll", "mjj", "basic", "bdtinput", "ht", "other", "llidisoWeight", 'jjbtagWeight', 'trigeffWeight', 'puWeight', 'DYNobtagToBTagMWeight', 'forSkimmer', 'csv', 'gen']
+# plots_llbb += ["bdtoutput"]
+
+def plots_to_branches(plots, tree):
+    for plot in plots:
+        # Ignore 2D plots
+        if ':::' in plot["variable"]:
+            continue
+
+        branch = {}
+        branch["name"] = plot["name"].split("_"+flavour)[0]
+        branch["variable"] = plot["variable"]
+        if 'type' in plot:
+            branch['type'] = plot['type']
+
+        tree["branches"].append(branch)

--- a/treeFactory_hh/generateTrees.py
+++ b/treeFactory_hh/generateTrees.py
@@ -1,52 +1,20 @@
 import ROOT as R
 import copy, sys, os, inspect 
 
-# Usage from histFactory/plots/HHAnalysis/ : ./../../build/createHistoWithMultiDraw.exe -d ../../samples.json generatePlots.py 
 scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
 sys.path.append(scriptDir)
 sys.path.append(os.path.join(scriptDir, "../histFactory_hh"))
+
 from basePlotter import *
-
-plots = []
-includes = []
-code_before_loop = ""
-
-# Needed to evaluate MVA outputs
-includes.append( os.path.join(scriptDir, "..", "common", "readMVA.h") )
-
-# For cluster reweighting
-includes.append( os.path.join(scriptDir, "..", "common", "reweight_v1tov3.h") )
-
-code_before_loop += """
-getBenchmarkReweighter("/home/fynu/sbrochet/scratch/Framework/CMSSW_7_6_5/src/cp3_llbb/HHTools/scripts/", 0, 11);
-"""
-
-sample_weights = {}
-for node in range(1, 13):
-    sample_weights[ "cluster_node_" + str(node) ] = "getBenchmarkReweighter().getWeight({}-1, hh_gen_mHH, hh_gen_costhetastar)".format(node)
-
-# Plot configuration
+from TreesDefinition import *
 
 # llbb 
 basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = "nominal")
-weights_llbb = []
-flavour = "All"
-categories_llbb = [flavour]
-stage_llbb = "no_cut"
-plots_llbb = ["mll", "mjj", "basic", "bdtinput", "ht", "other", "llidisoWeight", 'jjbtagWeight', 'trigeffWeight', 'puWeight', 'forSkimmer', 'csv', 'gen']
-plots_llbb += ["bdtoutput"]
-plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = "nominal", weights = weights_llbb, requested_plots = plots_llbb))
+plots = basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = "nominal", weights = weights_llbb, requested_plots = plots_llbb)
 
 tree = {}
 tree["name"] = "t"
 tree["cut"] = basePlotter.joinCuts(basePlotter.sanityCheck, basePlotter.dict_cat_cut["All"])
 tree["branches"] = []
 
-for plot in plots :
-    branch = {}
-    branch["name"] = plot["name"].split("_"+flavour)[0]
-    branch["variable"] = plot["variable"]
-    tree["branches"].append(branch)
-    
-for banch in tree["branches"] :
-    print banch
+plots_to_branches(plots, tree)

--- a/treeFactory_hh/generateTreesForDY.py
+++ b/treeFactory_hh/generateTreesForDY.py
@@ -1,0 +1,44 @@
+import ROOT as R
+import copy, sys, os, inspect 
+
+scriptDir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+sys.path.append(scriptDir)
+sys.path.append(os.path.join(scriptDir, "../histFactory_hh"))
+
+from basePlotter import *
+from TreesDefinition import *
+
+# llbb 
+basePlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_nobtag_csv", btagWP_str = 'nobtag', objects = "nominal")
+plots.extend(basePlotter.generatePlots(categories_llbb, stage_llbb, systematic = "nominal", weights = weights_llbb, requested_plots = plots_llbb))
+
+tree = {}
+tree["name"] = "t"
+tree["cut"] = basePlotter.joinCuts(basePlotter.sanityCheck, basePlotter.dict_cat_cut["All"])
+tree["branches"] = []
+
+plots_to_branches(plots, tree)
+
+
+llbbPlotter = BasePlotter(baseObjectName = "hh_llmetjj_HWWleptons_btagM_csv", btagWP_str = 'medium', objects = "nominal")
+
+is_llbb = llbbPlotter.joinCuts(llbbPlotter.sanityCheck, llbbPlotter.dict_cat_cut['All'])
+
+tree["branches"].append({
+    'name': 'is_llbb',
+    'variable': is_llbb
+    })
+
+plots = llbbPlotter.generatePlots(categories_llbb, stage_llbb, systematic="nominal", weights=weights_llbb, requested_plots=['jjbtagWeight'])
+
+for plot in plots:
+    # Protect each variable by the 'is_llbb' cut
+    new_variable = '((%s) ? %s : 1.)' % (is_llbb, plot['variable'])
+
+    branch = {}
+    branch["name"] = plot["name"].split("_"+flavour)[0]
+    branch["variable"] = new_variable
+    if 'type' in plot:
+        branch['type'] = plot['type']
+
+    tree["branches"].append(branch)


### PR DESCRIPTION
Note: first commit is from #53 

Currently, for every backgrounds, special histograms containing the nobtag -> btagM weights are created. This is not really a problem, but it does make sense only for DY. If one adds the neural net output in the list of histograms to be produced, evaluation will occurs on **every** selected events, and not anymore only of events with 2-btagged jets. Since evaluating the neural net is not a really fast operation, it's preferable to avoid to do it for histograms we don't even care.

This PR adds a protection to all the plots produced with the nobtag -> btagM weight: they are now filled only when running over DY. I also did a bit of cleanup removing unused arguments and stuff like that.