### PR TITLE
Optimize Keras NN evaluation

### DIFF
--- a/common/include/utils.h
+++ b/common/include/utils.h
@@ -9,6 +9,9 @@
 #include <Math/Vector4D.h>
 #include <Math/VectorUtil.h>
 
+#include <KerasModelEvaluator.h>
+#include <TMVAEvaluator.h>
+
 typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
 
 // From https://stackoverflow.com/questions/35985960/c-why-is-boosthash-combine-the-best-way-to-combine-hash-values
@@ -47,22 +50,8 @@ template<typename Evaluator>
 class MVAEvaluatorCache {
     public:
         MVAEvaluatorCache(const Evaluator& evaluator): m_evaluator(evaluator) {}
-
-        double evaluate(const std::vector<double>& values) {
-
-            auto it = m_cache.find(values);
-            if (it == m_cache.end()) {
-                double result = m_evaluator.evaluate(values);
-                m_cache.emplace(values, result);
-                return result;
-            } else {
-                return it->second;
-            }
-        }
-
-        void clear() {
-            m_cache.clear();
-        }
+        double evaluate(const std::vector<double>& values);
+        void clear();
 
     private:
 

--- a/common/src/utils.cc
+++ b/common/src/utils.cc
@@ -2,6 +2,26 @@
 
 #include "utils.h"
 
+template<typename Evaluator>
+double MVAEvaluatorCache<Evaluator>::evaluate(const std::vector<double>& values) {
+    auto it = m_cache.find(values);
+    if (it == m_cache.end()) {
+        double result = m_evaluator.evaluate(values);
+        m_cache.emplace(values, result);
+        return result;
+    } else {
+        return it->second;
+    }
+}
+
+template<typename Evaluator>
+void MVAEvaluatorCache<Evaluator>::clear() {
+    m_cache.clear();
+}
+
+template class MVAEvaluatorCache<KerasModelEvaluator>;
+template class MVAEvaluatorCache<TMVAEvaluator>;
+
 double Lerp(double v0, double v1, double t) {
     return (1 - t) * v0 + t * v1;
 }

--- a/factories_hh/basePlotter.py
+++ b/factories_hh/basePlotter.py
@@ -67,9 +67,15 @@ def default_headers():
             ]
 
 def default_include_directories(scriptDir):
-    return [
+    paths = [
             os.path.join(scriptDir, "..", "common", "include"),
             ]
+
+    # We need numpy headers for Keras NN evaluator
+    import numpy as np
+    paths.append(np.get_include())
+
+    return paths
 
 def default_sources(scriptDir):
     files = [


### PR DESCRIPTION
Two things:
 - Use numpy C api to create the input array. This allows to just reinterpret the memory as a numpy array instead of creating a new one from scratch and moving memory around.
 - Move caching implementation into .cc file to ensure the code is compiled with optimization, since the only consumer of the code is `Plotter.cc`, which is not compiled with optimization.