### PR TITLE
Evaluate NN using LWTNN instead of Keras

### DIFF
--- a/common/include/LWTNNEvaluator.h
+++ b/common/include/LWTNNEvaluator.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <lwtnn/LightweightNeuralNetwork.hh>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+/**
+ * A class acting as a wrapping around a python script, allowing to evaluate a keras model
+ */
+class LWTNNEvaluator {
+    public:
+        explicit LWTNNEvaluator(const std::string& lwtnn_model_filename, const std::vector<std::string>& inputs_name);
+
+        double evaluate(const std::vector<double>& values) const;
+
+        ~LWTNNEvaluator();
+
+    private:
+        // Python argv
+        char* argv[1];
+
+        std::unique_ptr<lwt::LightweightNeuralNetwork> nn;
+        std::vector<std::string> inputs_name;
+
+        mutable std::map<std::string, double> inputs;
+};

--- a/common/include/utils.h
+++ b/common/include/utils.h
@@ -9,9 +9,6 @@
 #include <Math/Vector4D.h>
 #include <Math/VectorUtil.h>
 
-#include <KerasModelEvaluator.h>
-#include <TMVAEvaluator.h>
-
 typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiE4D<float>> LorentzVector;
 
 // From https://stackoverflow.com/questions/35985960/c-why-is-boosthash-combine-the-best-way-to-combine-hash-values

--- a/common/src/LWTNNEvaluator.cc
+++ b/common/src/LWTNNEvaluator.cc
@@ -1,0 +1,33 @@
+#include "LWTNNEvaluator.h"
+
+#include <lwtnn/parse_json.hh>
+
+#include <fstream>
+
+LWTNNEvaluator::LWTNNEvaluator(const std::string& lwtnn_model_filename, const std::vector<std::string>& inputs_name): inputs_name(inputs_name) {
+
+    std::cout << "Initializing LWTNN evaluator using " << lwtnn_model_filename << std::endl;
+
+    std::ifstream config_file(lwtnn_model_filename);
+    auto config = lwt::parse_json(config_file);
+
+    nn.reset(new lwt::LightweightNeuralNetwork(config.inputs, config.layers, config.outputs));
+
+    for (const auto& name: inputs_name) {
+        inputs.emplace(name, 0);
+    }
+
+    std::cout << "Done." << std::endl;
+}
+
+LWTNNEvaluator::~LWTNNEvaluator() {
+}
+
+double LWTNNEvaluator::evaluate(const std::vector<double>& values) const {
+    size_t index = 0;
+    for (const auto& name: inputs_name) {
+        inputs[name] = values[index++];
+    }
+
+    return nn->compute(inputs)["signal"];
+}

--- a/common/src/utils.cc
+++ b/common/src/utils.cc
@@ -2,6 +2,10 @@
 
 #include "utils.h"
 
+#include <KerasModelEvaluator.h>
+#include <TMVAEvaluator.h>
+#include <LWTNNEvaluator.h>
+
 template<typename Evaluator>
 double MVAEvaluatorCache<Evaluator>::evaluate(const std::vector<double>& values) {
     auto it = m_cache.find(values);
@@ -21,6 +25,7 @@ void MVAEvaluatorCache<Evaluator>::clear() {
 
 template class MVAEvaluatorCache<KerasModelEvaluator>;
 template class MVAEvaluatorCache<TMVAEvaluator>;
+template class MVAEvaluatorCache<LWTNNEvaluator>;
 
 double Lerp(double v0, double v1, double t) {
     return (1 - t) * v0 + t * v1;

--- a/factories_hh/generatePlots.py
+++ b/factories_hh/generatePlots.py
@@ -109,6 +109,7 @@ code_after_loop = default_code_after_loop()
 include_directories = default_include_directories(scriptDir)
 headers = default_headers()
 libraries = default_libraries()
+library_directories = default_library_directories()
 sources = default_sources(scriptDir)
 
 ####### Reweighting -- ME-based -- only for signal #########

--- a/factories_hh/generateTrees.py
+++ b/factories_hh/generateTrees.py
@@ -38,6 +38,7 @@ code_after_loop = default_code_after_loop()
 include_directories = default_include_directories(scriptDir)
 headers = default_headers()
 libraries = default_libraries()
+library_directories = default_library_directories()
 sources = default_sources(scriptDir)
 
 ####### Reweighting -- ME-based -- only for signal #########

--- a/factories_hh/launchFactory.py
+++ b/factories_hh/launchFactory.py
@@ -247,6 +247,15 @@ TestPlots_ForData = Configuration('generatePlots.py', workflow='test', suffix='_
 #            'llbb_stages': ['mll_cut'],
 #        })
 
+LightTestPlots_ForMC = Configuration('generatePlots.py', workflow='light_test', mode='plots', samples=["DY_NLO"], generation_args={
+            'sample_type': 'MC',
+            'syst': False,
+            'llbb_plots': ['basic', 'nn'],
+            'llbb_stages': ['mll_cut'],
+            #'llbb_plots': ['basic', 'dy_bdt', 'nn'],
+            'llbb_categories': ['MuMu']
+        })
+
 ##### Parse arguments and do actual work ####
 
 parser = argparse.ArgumentParser(description='Facility to submit histFactory jobs on condor.')

--- a/mvaTraining/common.py
+++ b/mvaTraining/common.py
@@ -834,3 +834,13 @@ def save_training_parameters(output, model, **kwargs):
     with open(os.path.join(output, 'parameters.json'), 'w') as f:
         json.dump(parameters, f, indent=4)
 
+
+def export_for_lwtnn(model, name):
+    base = os.path.splitext(name)
+
+    # Export architecture of the model
+    with open(base + '_arch.json', 'w') as f:
+        f.write(model.to_json())
+
+    # And the weights
+    model.save_weights(base + "_weights.h5")

--- a/mvaTraining/convertToLWTNNFormat.py
+++ b/mvaTraining/convertToLWTNNFormat.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+#
+# Converter from Keras (version 1.0.0) saved NN to JSON
+"""____________________________________________________________________
+Variable specification file
+
+In additon to the standard Keras architecture and weights files, you
+must provide a "variable specification" json file with the following
+format:
+
+  {
+    "inputs": [
+      {"name": variable_name,
+       "scale": scale,
+       "offset": offset,
+       "default": default_value},
+      ...
+      ],
+    "class_labels": [output_class_1_name, output_class_2_name, ...],
+    "keras_version": "1.0.0",
+    "miscellaneous": {"key": "value"}
+  }
+
+where `scale` and `offset` account for any scaling and shifting to the
+input variables in preprocessing. The "default" value is optional.
+
+The "miscellaneous" object is also optional and can contain (key,
+value) pairs of strings to pass to the application.
+
+"""
+
+import argparse
+import warnings
+import json
+import h5py
+import numpy as np
+import os
+from collections import Counter
+
+def _run():
+    """Top level routine"""
+    args = _get_args()
+
+    if args.resonant:
+        inputs = 'hh_resonant_lwtnn_mapping.json'
+        prefix = 'hh_resonant_trained_model'
+    else:
+        inputs = 'hh_nonresonant_lwtnn_mapping.json'
+        prefix = 'hh_nonresonant_trained_model'
+
+    with open(os.path.join(args.input_folder, prefix + '_arch.json'), 'r') as arch_file:
+        arch = json.load(arch_file)
+
+    with open(inputs, 'r') as inputs_file:
+        inputs = json.load(inputs_file)
+
+    file_version = inputs.get('keras_version')
+    if not file_version.startswith('1.0'):
+        warnings.warn(
+            "This converter was developed for Keras version 1.0.0. "
+            "The provided files were generated using version {} and "
+            "therefore the conversion might break.".format(
+                file_version))
+
+    with h5py.File(os.path.join(args.input_folder, prefix + '_weights.h5'), 'r') as h5:
+        out_dict = {
+            'layers': _get_layers(arch, inputs, h5),
+        }
+        out_dict.update(_parse_inputs(inputs))
+
+    with open(os.path.join(args.input_folder, prefix + '_lwtnn.json'), 'w') as f:
+        json.dump(out_dict, f, sort_keys=True)
+
+def _get_args():
+    parser = argparse.ArgumentParser(
+        description="Converter from Keras saved NN to JSON",
+        epilog=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('input_folder', help='Input folder')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--resonant', action='store_true', help='Resonant network')
+    group.add_argument('--non-resonant', action='store_true', help='Non-resonant network')
+
+    return parser.parse_args()
+
+# translate from keras to json representation
+_activation_map = {
+    'relu': 'rectified',
+    'sigmoid': 'sigmoid',
+    None: 'linear',
+    # TODO: pass through unknown types rather than defining them as
+    # themselves?
+    'linear': 'linear',
+    'softmax': 'softmax',
+    'tanh': 'tanh',
+    'hard_sigmoid': 'hard_sigmoid',
+}
+
+# utility function to handle keras layer naming
+def _get_h5_layers(layer_group):
+    """
+    For some reason Keras prefixes the datasets we need with the group
+    name. This function returns a dictionary of the datasets, keyed
+    with the group name stripped off.
+    """
+    prefixes = set()
+    numbers = set()
+    layers = {}
+    for name, ds in layer_group.items():
+        prefix, number, name = name.split('_', 2)
+        prefixes.add(prefix)
+        numbers.add(number)
+        name, _ = name.split(':', 2)
+        layers[name] = np.asarray(ds)
+    assert len(prefixes) == 1, 'too many prefixes: {}'.format(prefixes)
+    assert len(numbers) == 1, 'too many numbers: {}'.format(numbers)
+    return layers
+
+# __________________________________________________________________________
+# Layer converters
+#
+# Each of these converters takes three arguments:
+#  - The H5 Group with the layer parameters
+#  - The layer configuration
+#  - The number of inputs (for error checking)
+#
+# Each returns two outputs:
+#  - A dictionary of layer information which can be serialized to JSON
+#  - The number of outputs (also for error checking)
+
+def _get_dense_layer_parameters(h5, layer_config, n_in):
+    """Get weights, bias, and n-outputs for a dense layer"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    weights = layers['W']
+    bias = layers['b']
+    assert weights.shape[1] == bias.shape[0]
+    assert weights.shape[0] == n_in
+    # TODO: confirm that we should be transposing the weight
+    # matrix the Keras case
+    return_dict = {
+        'weights': weights.T.flatten('C').tolist(),
+        'bias': bias.flatten('C').tolist(),
+        'architecture': 'dense',
+        'activation': _activation_map[layer_config['activation']],
+    }
+    return return_dict, weights.shape[1]
+
+def _normalization_parameters(h5, layer_config, n_in):
+    """Get weights (gamma), bias (beta), for normalization layer"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    gamma = layers['gamma']
+    beta = layers['beta']
+    mean = layers['running_mean']
+    stddev = layers['running_std']
+    # Do some checks
+    assert gamma.shape[0] == beta.shape[0]
+    assert mean.shape[0] == stddev.shape[0]
+    assert gamma.shape[0] == n_in
+    assert 'activation' not in layer_config
+    epsilon = layer_config['epsilon']
+    scale = gamma / np.sqrt(stddev + epsilon)
+    offset = -mean+(beta*np.sqrt(stddev + epsilon)/(gamma))
+    return_dict = {
+        'weights': scale.T.flatten('C').tolist(),
+        'bias': offset.flatten('C').tolist(),
+        'architecture': 'normalization',
+    }
+    return return_dict, scale.shape[0]
+
+def _get_maxout_layer_parameters(h5, layer_config, n_in):
+    """Get weights, bias, and n-outputs for a maxout layer"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    weights = layers['W']
+    bias = layers['b']
+
+    # checks (note the transposed arrays)
+    wt_layers, wt_in, wt_out = weights.shape
+    bias_layers, bias_n = bias.shape
+    assert wt_out == bias_n
+    assert wt_in == n_in, '{} != {}'.format(wt_in, n_in)
+    assert wt_layers == bias_layers
+    assert 'activation' not in layer_config
+
+    sublayers = []
+    for nnn in range(weights.shape[0]):
+        w_slice = weights[nnn,:,:]
+        b_slice = bias[nnn,:]
+        sublayer = {
+            'weights': w_slice.T.flatten().tolist(),
+            'bias': b_slice.flatten().tolist(),
+            'architecture': 'dense'
+        }
+        sublayers.append(sublayer)
+    return {'sublayers': sublayers, 'architecture': 'maxout',
+            'activation': 'linear'}, wt_out
+
+# TODO: unify LSTM, highway, and GRU here, they do almost the same thing
+def _lstm_parameters(h5, layer_config, n_in):
+    """LSTM parameter converter"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    n_out = layers['W_o'].shape[1]
+
+    submap = {}
+    for gate in 'cfio':
+        submap[gate] = {
+            'U': layers['U_' + gate].T.flatten().tolist(),
+            'weights': layers['W_' + gate].T.flatten().tolist(),
+            'bias': layers['b_' + gate].flatten().tolist(),
+        }
+    return {'components': submap, 'architecture': 'lstm',
+            'activation': _activation_map[layer_config['activation']],
+            'inner_activation': _activation_map[layer_config['inner_activation']]}, n_out
+
+def _get_highway_layer_parameters(h5, layer_config, n_in):
+    """Get weights, bias, and n-outputs for a highway layer"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    n_out = layers['W'].shape[1]
+
+    submap = {}
+    for gate in ['', '_carry']:
+        submap[gate[1:] or 't'] = {
+            'weights': layers['W' + gate].T.flatten().tolist(),
+            'bias': layers['b' + gate].flatten().tolist(),
+        }
+    return {'components': submap, 'architecture': 'highway',
+            'activation': _activation_map[layer_config['activation']]}, n_out
+
+def _gru_parameters(h5, layer_config, n_in):
+    """GRU parameter converter"""
+    layer_group = h5[layer_config['name']]
+    layers = _get_h5_layers(layer_group)
+    n_out = layers['W_h'].shape[1]
+
+    submap = {}
+    for gate in 'zrh':
+        submap[gate] = {
+            'U': layers['U_' + gate].T.flatten().tolist(),
+            'weights': layers['W_' + gate].T.flatten().tolist(),
+            'bias': layers['b_' + gate].flatten().tolist(),
+        }
+    return {'components': submap, 'architecture': 'gru',
+            'activation': layer_config['activation'],
+            'inner_activation': layer_config['inner_activation']}, n_out
+
+def _get_merge_layer_parameters(h5, layer_config, n_in):
+    """
+    Merge layer converter, currently only supports embedding, and only
+    for the first layer.
+    """
+    sum_inputs = 0
+    sum_outputs = 0
+    sublayers = []
+    for sublayer in layer_config['layers']:
+        assert sublayer['class_name'].lower() == 'sequential'
+        assert len(sublayer['config']) == 1
+        subcfg = sublayer['config'][0]['config']
+        class_name = sublayer['config'][0]['class_name'].lower()
+
+        if class_name == 'embedding':
+            layers = _get_h5_layers(h5[subcfg['name']])
+            sublayer = {
+                'weights': layers['W'].T.flatten().tolist(),
+                'index': sum_inputs,
+                'n_out': subcfg['output_dim']
+                }
+            sublayers.append(sublayer)
+            sum_inputs += 1
+            sum_outputs += subcfg['output_dim']
+        elif class_name == 'activation':
+            if subcfg['activation'] != 'linear':
+                raise ValueError('we only support linear activation here')
+            dims = subcfg['batch_input_shape'][2]
+            sum_inputs += dims
+            sum_outputs += dims
+        elif class_name == 'masking':
+            dims = subcfg['batch_input_shape'][2]
+            sum_inputs += dims
+            sum_outputs += dims
+        else:
+            raise ValueError('unsupported merge layer {}'.format(class_name))
+
+    assert sum_inputs == n_in
+    return {'sublayers': sublayers, 'architecture': 'embedding',
+            'activation': 'linear'}, sum_outputs
+
+
+def _activation_parameters(h5, layer_config, n_in):
+    """Return dummy parameters"""
+    return {'weights':[], 'bias':[], 'architecture':'dense',
+            'activation':_activation_map[layer_config['activation']]}, n_in
+
+_layer_converters = {
+    'dense': _get_dense_layer_parameters,
+    'batchnormalization': _normalization_parameters,
+    'highway': _get_highway_layer_parameters,
+    'maxoutdense': _get_maxout_layer_parameters,
+    'lstm': _lstm_parameters,
+    'gru': _gru_parameters,
+    'merge': _get_merge_layer_parameters,
+    'activation': _activation_parameters,
+    }
+_skip_layers = {'flatten', 'dropout', 'masking'}
+
+# __________________________________________________________________________
+# master layer converter / inputs function
+
+def _get_layers(network, inputs, h5):
+    layers = []
+    in_layers = network['config']
+    n_out = len(inputs['inputs'])
+    for layer_n in range(len(in_layers)):
+        # get converter for this layer
+        layer_arch = in_layers[layer_n]
+        layer_type = layer_arch['class_name'].lower()
+        if layer_type in _skip_layers: continue
+        convert = _layer_converters[layer_type]
+
+        # build the out layer
+        out_layer, n_out = convert(h5, layer_arch['config'], n_out)
+        layers.append(out_layer)
+    return layers
+
+def _parse_inputs(keras_dict):
+    inputs = []
+    defaults = {}
+    for val in keras_dict['inputs']:
+        inputs.append({x: val[x] for x in ['offset', 'scale', 'name']})
+
+        # maybe fill default
+        default = val.get("default")
+        if default is not None:
+            defaults[val['name']] = default
+    out = {
+        'inputs': inputs,
+        'outputs': keras_dict['class_labels'],
+        'defaults': defaults,
+    }
+    if 'miscellaneous' in keras_dict:
+        misc_dict = {}
+        for key, val in keras_dict['miscellaneous'].items():
+            misc_dict[str(key)] = str(val)
+        out['miscellaneous'] = misc_dict
+    return out
+
+if __name__ == '__main__':
+    _run()

--- a/mvaTraining/hh_nonresonant_lwtnn_mapping.json
+++ b/mvaTraining/hh_nonresonant_lwtnn_mapping.json
@@ -1,0 +1,73 @@
+{
+    "inputs": [
+        {
+            "name": "jj_pt",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_pt",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_M",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_DR_l_l",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "jj_DR_j_j",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_DPhi_ll_jj",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_minDR_l_j",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_MTformula",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "isSF",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "k_l",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "k_t",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        }
+    ],
+    "class_labels": ["signal", "background"],
+    "keras_version": "1.0.0",
+    "miscellaneous": {}
+}

--- a/mvaTraining/hh_resonant_lwtnn_mapping.json
+++ b/mvaTraining/hh_resonant_lwtnn_mapping.json
@@ -1,0 +1,67 @@
+{
+    "inputs": [
+        {
+            "name": "jj_pt",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_pt",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_M",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "ll_DR_l_l",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "jj_DR_j_j",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_DPhi_ll_jj",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_minDR_l_j",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "llmetjj_MTformula",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "isSF",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        },
+        {
+            "name": "M_X",
+            "scale": 1,
+            "offset": 0,
+            "default": 0
+        }
+    ],
+    "class_labels": ["signal", "background"],
+    "keras_version": "1.0.0",
+    "miscellaneous": {}
+}

--- a/mvaTraining/trainNonResonantModel.py
+++ b/mvaTraining/trainNonResonantModel.py
@@ -157,6 +157,7 @@ if training:
 
 model = keras.models.load_model(output_model_filename)
 
+export_for_lwtnn(model, output_model_filename)
 draw_non_resonant_training_plots(model, dataset, output_folder, split_by_parameters=add_parameters_columns)
 
 print("All done. Training time: %s" % str(training_time))

--- a/mvaTraining/trainResonantModel.py
+++ b/mvaTraining/trainResonantModel.py
@@ -115,6 +115,7 @@ if training:
 
 model = keras.models.load_model(output_model_filename)
 
+export_for_lwtnn(model, output_model_filename)
 draw_resonant_training_plots(model, dataset, output_folder, split_by_mass=add_mass_column)
 
 print("All done. Training time: %s" % str(training_time))


### PR DESCRIPTION
LWTNN (https://github.com/lwtnn/lwtnn) is a lightweight library to evaluate NN, supporting NN trained with Keras. The big advantage here is that it's plain C++, so no need to go through python to evaluate the NN. From my tests, I see a speedup of about 4 between plain Keras and LWTNN. I also check that the output is exactly the same between the Keras-based and LWTNN-based implementation.

Some technicalities: LWTNN will be included by default into CMSSW in some upcoming release, but it's not the case currently (at least not in 8.0.26p2). But, it's already there on /cvmfs, so , instead of including a copy into our repository, the scripts are configured to use the version from /cvmfs. Everything is hardcoded for the moment, and we should remember to use `scram` at some point to grab the include and library path for lwtnn once it's included into a CMSSW release.

I also added into the `mvaTraining` repository a tool to convert Keras models into LWTNN models. It's based on the official tool (https://github.com/lwtnn/lwtnn/blob/master/converters/keras2json.py) with some bug fixes and adapted to our case. I also added mapping for resonant and non-resonant.

It should be completely transparent to the user. I'd appreciate if someone can pull this PR and test locally before merging!

Finally, thanks for @pieterdavid for the idea of using LWTNN :+1: 